### PR TITLE
fix crypto donation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Completely rewritten to accommodate new features and to be even speedier, Open T
   <img src="https://raw.githubusercontent.com/Fredolx/open-tv/refs/heads/main/readme_imgs/aur-open-tv.svg" width="350" />
 </a>
 
-# This project NEEDS your help. Please consider donating on [Github](https://github.com/sponsors/Fredolx), [Patreon](https://www.patreon.com/fredol), [Paypal](https://paypal.me/fredolx) or directly by [crypto](#crypto)
+# This project NEEDS your help. Please consider donating on [Github](https://github.com/sponsors/Fredolx), [Patreon](https://www.patreon.com/fredol), [Paypal](https://paypal.me/fredolx) or directly by [crypto](#donate-crypto-thank-you)
 I've been developing and maintaining this project alone and for entirely for free over the past 2 years. I am in dire need of support to continue developing this project. I've never added annoying donation pop-ups or anything of the sort to make sure you have the fastest and cleanest IPTV experience and I'm committed to keep this project FREE & OPEN-SOURCE. To keep that commitment, I need your support!
 
 ![Image of the app](https://github.com/Fredolx/open-tv/blob/main/screenshots/demo1.png)


### PR DESCRIPTION
The crypto donation link doesn't link to the actual crypto donation section of the readme. I fixed it