### PR TITLE
feat: add Clear History option in Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-tv",
-  "version": "1.5.2",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-tv",
-      "version": "1.5.2",
+      "version": "1.6.1",
       "dependencies": {
         "@angular/animations": "^17.3.0",
         "@angular/cdk": "^17.3.10",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,7 +101,8 @@ pub fn run() {
             add_last_watched,
             backup_favs,
             restore_favs,
-            abort_download
+            abort_download,
+            clear_history
         ])
         .setup(|app| {
             app.manage(Mutex::new(AppState {
@@ -510,4 +511,9 @@ fn backup_favs(id: i64, path: String) -> Result<(), String> {
 #[tauri::command(async)]
 fn restore_favs(id: i64, path: String) -> Result<(), String> {
     utils::restore_favs(id, path).map_err(map_err_frontend)
+}
+
+#[tauri::command(async)]
+fn clear_history() -> Result<(), String> {
+    sql::clear_history().map_err(map_err_frontend)
 }

--- a/src-tauri/src/sql.rs
+++ b/src-tauri/src/sql.rs
@@ -1207,3 +1207,16 @@ pub fn add_last_watched(id: i64) -> Result<()> {
     )?;
     Ok(())
 }
+
+pub fn clear_history() -> Result<()> {
+    let sql = get_conn()?;
+    sql.execute(
+        r#"
+          UPDATE channels
+          SET last_watched = NULL
+          WHERE last_watched IS NOT NULL
+        "#,
+        params![],
+    )?;
+    Ok(())
+}

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -56,6 +56,16 @@ button:hover .nuke {
     transform: scale(125%);
 }
 
+button .history {
+    width: 1.5rem;
+    height: 1.5rem;
+    transition: transform 0.3s ease;
+}
+
+button:hover .history {
+    transform: scale(125%);
+}
+
 .folder {
     height: 1rem;
     width: 1rem;

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -238,7 +238,7 @@
         />
       </svg>
     </button>
-    <button ngbTooltip="Clear your watch history" class="btn btn-warning d-inline-flex align-items-center"
+    <button class="btn btn-warning d-inline-flex align-items-center"
     [disabled]="memory.Loading" (click)="clearHistory()">
     Clear history
     <svg class="history ms-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -238,6 +238,14 @@
         />
       </svg>
     </button>
+    <button ngbTooltip="Clear your watch history" class="btn btn-warning d-inline-flex align-items-center"
+    [disabled]="memory.Loading" (click)="clearHistory()">
+    Clear history
+    <svg class="history ms-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <path fill="currentColor"
+        d="M13.5,8H12V13L16.28,15.54L17,14.33L13.5,12.25V8M13,3A9,9 0 0,0 4,12H1L4.89,15.89L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3" />
+    </svg>
+  </button>
   </div>
 </div>
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -225,6 +225,17 @@
       </svg>
     </button>
     <button
+      [disabled]="memory.Loading"
+      (click)="clearHistory()"
+      class="btn btn-secondary d-inline-flex align-items-center"
+    >
+      Clear history
+      <svg class="history ms-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path fill="currentColor"
+          d="M13.5,8H12V13L16.28,15.54L17,14.33L13.5,12.25V8M13,3A9,9 0 0,0 4,12H1L4.89,15.89L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3" />
+      </svg>
+    </button>
+    <button
       ngbTooltip="Use this if an upgrade didn't fix a bug you're experiencing"
       class="btn btn-danger d-inline-flex align-items-center"
       [disabled]="memory.Loading"
@@ -238,14 +249,6 @@
         />
       </svg>
     </button>
-    <button class="btn btn-warning d-inline-flex align-items-center"
-    [disabled]="memory.Loading" (click)="clearHistory()">
-    Clear history
-    <svg class="history ms-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-      <path fill="currentColor"
-        d="M13.5,8H12V13L16.28,15.54L17,14.33L13.5,12.25V8M13,3A9,9 0 0,0 4,12H1L4.89,15.89L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3" />
-    </svg>
-  </button>
   </div>
 </div>
 

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -161,6 +161,16 @@ export class SettingsComponent {
     this.memory.ModalRef.componentInstance.name = "ConfirmDeleteModal";
   }
 
+  async clearHistory() {
+    await this.memory.tryIPC(
+      "History cleared successfully",
+      "Failed to clear history",
+      async () => {
+        await invoke("clear_history");
+      }
+    );
+  }
+
   ngOnDestroy(): void {
     this.subscriptions.forEach((x) => x.unsubscribe());
   }

--- a/src/app/whats-new-modal/whats-new-modal.component.html
+++ b/src/app/whats-new-modal/whats-new-modal.component.html
@@ -18,7 +18,6 @@
   <br />
   <h3>Changes:</h3>
   <ul>
-    <li>Added ability to clear watch history</li>
     <li>
       Added timeshift/replay/catchback for live channels (xtream, in the epg for each channel)
     </li>

--- a/src/app/whats-new-modal/whats-new-modal.component.html
+++ b/src/app/whats-new-modal/whats-new-modal.component.html
@@ -18,6 +18,7 @@
   <br />
   <h3>Changes:</h3>
   <ul>
+    <li>Added ability to clear watch history</li>
     <li>
       Added timeshift/replay/catchback for live channels (xtream, in the epg for each channel)
     </li>


### PR DESCRIPTION
Adds a new “Clear History” button to the Settings screen, letting users instantly erase their watch/viewing history. When tapped, the button prompts for confirmation and then clears all stored history entries. This enhancement gives users direct control over their privacy and data with a single, easy-to-find action in the app’s settings.