### PR TITLE
feat(settings): add user agent configuration

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_SORT: &str = "defaultSort";
 pub const ENABLE_HWDEC: &str = "enableHWDEC";
 pub const ALWAYS_ASK_SAVE: &str = "alwaysAskSave";
 pub const ENABLE_GPU: &str = "enableGPU";
+pub const USER_AGENT: &str = "userAgent";
 
 pub fn get_settings() -> Result<Settings> {
     let map = sql::get_settings()?;
@@ -35,6 +36,7 @@ pub fn get_settings() -> Result<Settings> {
         enable_hwdec: map.get(ENABLE_HWDEC).and_then(|s| s.parse().ok()),
         always_ask_save: map.get(ALWAYS_ASK_SAVE).and_then(|s| s.parse().ok()),
         enable_gpu: map.get(ENABLE_GPU).and_then(|s| s.parse().ok()),
+        user_agent: map.get(USER_AGENT).and_then(|s| s.parse().ok()),
     };
     Ok(settings)
 }
@@ -82,6 +84,9 @@ pub fn update_settings(settings: Settings) -> Result<()> {
     }
     if let Some(gpu) = settings.enable_gpu {
         map.insert(ENABLE_GPU.to_string(), gpu.to_string());
+    }
+    if let Some(ua) = settings.user_agent {
+        map.insert(USER_AGENT.to_string(), ua.to_string());
     }
     sql::update_settings(map)?;
     Ok(())

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -76,6 +76,7 @@ pub struct Settings {
     pub enable_hwdec: Option<bool>,
     pub always_ask_save: Option<bool>,
     pub enable_gpu: Option<bool>,
+    pub user_agent: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/src/app/models/settings.ts
+++ b/src/app/models/settings.ts
@@ -12,4 +12,5 @@ export class Settings {
   enable_hwdec?: boolean;
   always_ask_save?: boolean;
   enable_gpu?: boolean;
+  user_agent?: string;
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -203,6 +203,22 @@
 
   <div class="row mt-3 align-items-center">
     <div class="col-4">
+      <span>User Agent</span>
+    </div>
+    <div class="col">
+      <textarea
+        #user_agent
+        id="user_agent"
+        [(ngModel)]="settings.user_agent"
+        (ngModelChange)="this.updateSettings()"
+        placeholder="User agent string applied to all requests. Ex : Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
+        class="form-control"
+      ></textarea>
+    </div>
+  </div>
+
+  <div class="row mt-3 align-items-center">
+    <div class="col-4">
       <span
         [ngbTooltip]="
           'Opens the file dialog for all downloads and recordings. Overrides recording path. '

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -29,6 +29,7 @@ export class SettingsComponent {
     enable_hwdec: true,
     always_ask_save: false,
     enable_gpu: false,
+    user_agent: "",
   };
   viewModeEnum = ViewMode;
   sources: Source[] = [];
@@ -89,6 +90,7 @@ export class SettingsComponent {
       if (this.settings.enable_hwdec == undefined) this.settings.enable_hwdec = true;
       if (this.settings.always_ask_save == undefined) this.settings.always_ask_save = false;
       if (this.settings.enable_gpu == undefined) this.settings.enable_gpu = false;
+      if (this.settings.user_agent == undefined) this.settings.user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/";
     });
   }
 


### PR DESCRIPTION
Uses a default User-Agent header unless it's updated in the settings.

fixes Fredolx/open-tv#261