### PR TITLE
Load more and scrolling in categories has duplicates.

### DIFF
--- a/src-tauri/src/sql.rs
+++ b/src-tauri/src/sql.rs
@@ -622,7 +622,7 @@ fn to_sql_like(query: Option<String>) -> String {
 
 pub fn search_group(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset = filters.page * PAGE_SIZE - PAGE_SIZE;
+    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let query = filters.query.unwrap_or("".to_string());
     let media_types = filters.media_types.context("no media types")?;
     let keywords: Vec<String> = match filters.use_keywords {


### PR DESCRIPTION
offset was overflowing the max u8 when clicking "load more" in categorises and would give the following message

thread 'tokio-runtime-worker' panicked at src/sql.rs:625:18: attempt to multiply with overflow

The same has been done in multiple places in this file already for offset I'm assuming this one was just missed.