### PR TITLE
fix: clear setInterval in LoadingComponent on destroy

### DIFF
--- a/src/app/loading/loading.component.ts
+++ b/src/app/loading/loading.component.ts
@@ -1,21 +1,29 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnDestroy } from "@angular/core";
 
 @Component({
   selector: "app-loading",
   templateUrl: "./loading.component.html",
   styleUrl: "./loading.component.css",
 })
-export class LoadingComponent {
+export class LoadingComponent implements OnDestroy {
   @Input()
   center: boolean = false;
   count = 0;
   texts: string[] = ["Consider donating to Fred TV", "Loading your channels..."];
 
   currentText: string = "";
+  private intervalId: ReturnType<typeof setInterval> | null = null;
 
   ngOnInit() {
     this.displayRandomText();
-    setInterval(() => this.displayRandomText(), 3500);
+    this.intervalId = setInterval(() => this.displayRandomText(), 3500);
+  }
+
+  ngOnDestroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
   }
 
   displayRandomText() {


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
- The `LoadingComponent`'s `setInterval` was never cleared, leaking intervals on every create/destroy cycle
- Store the interval ID and clear it in `ngOnDestroy`
- Implements `OnDestroy` interface

## Test plan
- [ ] Open app, navigate to trigger loading component, navigate away, verify no console errors or leaked timers