### PR TITLE
fix: clamp page to minimum 1 in search pagination

### DIFF
--- a/src-tauri/src/sql.rs
+++ b/src-tauri/src/sql.rs
@@ -464,7 +464,8 @@ pub fn search(filters: Filters) -> Result<Vec<Channel>> {
         return search_series(filters);
     }
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let media_types = match filters.series_id.is_some() {
         true => vec![1],
         false => filters.media_types.clone().unwrap(),
@@ -544,7 +545,8 @@ pub fn search(filters: Filters) -> Result<Vec<Channel>> {
 
 fn search_series(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let query = filters.query.unwrap_or("".to_string());
     let keywords: Vec<String> = match filters.use_keywords {
         true => query
@@ -816,7 +818,8 @@ fn apply_bulk_channels(
 
 fn search_hidden(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
 
     let media_types = match filters.series_id.is_some() {
         true => vec![1],
@@ -928,7 +931,8 @@ fn to_sql_like(query: Option<String>) -> String {
 
 pub fn search_group(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let query = filters.query.unwrap_or("".to_string());
     let media_types = filters.media_types.context("no media types")?;
     let keywords: Vec<String> = match filters.use_keywords {


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
- When `filters.page` is 0, the `u16` offset calculation underflows (`0 * PAGE_SIZE - PAGE_SIZE` wraps to a large value)
- Clamp page to minimum 1 before the calculation in all 4 search functions (`search`, `search_series`, `search_hidden`, `search_group`)

## Test plan
- [ ] Search for channels with page=0 in filters, verify no panic or unexpected results
- [ ] Normal pagination continues to work correctly