### PR TITLE
fix: use compound assignment in nav() focus calculation

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -546,7 +546,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
         break;
     }
     let goOverSize = this.shortFiltersMode() ? 1 : 2;
-    if (lowSize && tmpFocus % 3 == 0 && this.focusArea == FocusArea.Tiles) tmpFocus / 3;
+    if (lowSize && tmpFocus % 3 == 0 && this.focusArea == FocusArea.Tiles) tmpFocus /= 3;
     tmpFocus += this.focus;
     if (tmpFocus < 0) {
       this.changeFocusArea(false);


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
- `tmpFocus / 3` was a no-op (expression result discarded, not assigned back)
- Changed to `tmpFocus /= 3` so the division actually takes effect for keyboard navigation on small screens

## Test plan
- [ ] Use arrow key navigation on a small/mobile viewport, verify focus moves correctly