### PR TITLE
perf: add trackBy to channel ngFor and cache anyXtream()

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -80,10 +80,10 @@
       <div class="form-check form-check-inline form-switch">
         <input [(ngModel)]="chkMovie" (ngModelChange)="updateMediaTypes(mediaTypeEnum.movie)" class="form-check-input"
           id="filter-1" type="checkbox" />
-        <label *ngIf="anyXtream()" class="form-check-label" for="filter-1"> Movies/Vods </label>
-        <label *ngIf="!anyXtream()"> Movies/Vods/Series </label>
+        <label *ngIf="isAnyXtream" class="form-check-label" for="filter-1"> Movies/Vods </label>
+        <label *ngIf="!isAnyXtream"> Movies/Vods/Series </label>
       </div>
-      <div *ngIf="anyXtream()" class="form-check form-check-inline form-switch">
+      <div *ngIf="isAnyXtream" class="form-check form-check-inline form-switch">
         <input [(ngModel)]="chkSerie" (ngModelChange)="updateMediaTypes(mediaTypeEnum.serie)" class="form-check-input"
           id="filter-2" type="checkbox" />
         <label class="form-check-label" for="filter-2"> Series </label>
@@ -103,7 +103,7 @@
       </h4>
     </div>
     <div class="row gy-3" [@fade]="channelsVisible ? 'visible' : 'hidden'">
-      <app-channel-tile [attr.id]="i == 0 ? 'first' : null" *ngFor="let channel of channels; let i = index"
+      <app-channel-tile [attr.id]="i == 0 ? 'first' : null" *ngFor="let channel of channels; let i = index; trackBy: trackByChannelId"
         class="col-lg-4 col-md-4" [id]="i" [channel]="channel" [viewMode]="viewType"></app-channel-tile>
     </div>
   </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -99,6 +99,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
   loading = false;
   nodeStack: Stack = new Stack();
   showScrollTop = false;
+  isAnyXtream = false;
 
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -125,6 +126,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
         this.memory.trayEnabled = settings.enable_tray_icon ?? true;
         this.memory.AlwaysAskSave = settings.always_ask_save ?? false;
         this.memory.Sources = new Map(sources.filter((x) => x.enabled).map(s => [s.id!, s]));
+        this.isAnyXtream = this.anyXtream();
         if (sources.length == 0) this.reset();
         else {
           getVersion().then((version) => {
@@ -627,6 +629,10 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
     if (this.memory.currentContextMenu?.menuOpen) {
       this.memory.currentContextMenu?.closeMenu();
     }
+  }
+
+  trackByChannelId(index: number, channel: Channel): number {
+    return channel.id!;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
- Add `trackBy: trackByChannelId` to the channels `*ngFor` loop, preventing Angular from destroying and recreating all channel tile DOM nodes on every array reassignment (search, filter change, page load)
- Cache `anyXtream()` result as `isAnyXtream` property, set once when Sources are loaded, instead of calling the method on every change detection cycle (it iterates the entire Sources map each time)

## Test plan
- [ ] Navigate between views, search, filter by media type, verify channel tiles render correctly
- [ ] Verify Xtream-specific UI (Series filter checkbox) still shows/hides correctly based on source types
- [ ] Check for smoother scrolling and reduced jank on large channel lists