### PR TITLE
feat: add server-side recording system

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use anyhow::Context;
 use anyhow::Error;
+use std::sync::atomic::Ordering;
 
 use tauri::{AppHandle, Manager, State};
 use tokio::sync::Mutex;
@@ -20,6 +21,7 @@ use {
 pub mod bulk_action_type;
 pub mod epg;
 pub mod log;
+pub mod recording;
 pub mod m3u;
 pub mod media_type;
 pub mod mpv;
@@ -113,6 +115,9 @@ pub fn run() {
             hide_channel,
             hide_group,
             remove_from_history,
+            start_recording,
+            stop_recording,
+            get_active_recordings,
         ])
         .setup(|app| {
             app.manage(Mutex::new(AppState {
@@ -147,6 +152,17 @@ pub fn run() {
                 let window = _app.get_webview_window("main").expect("no main window");
                 let _ = window.show();
                 let _ = window.set_focus();
+            }
+            tauri::RunEvent::ExitRequested { .. } => {
+                // Signal all background processes to stop so they don't become orphans
+                let state: State<Mutex<AppState>> = _app.state();
+                if let Ok(state) = state.try_lock() {
+                    state.notify_stop.store(true, Ordering::Relaxed);
+                    state.restream_stop_signal.store(true, Ordering::Relaxed);
+                    for rec in state.active_recordings.values() {
+                        rec.stop_signal.store(true, Ordering::Relaxed);
+                    }
+                }
             }
             _ => {}
         });
@@ -558,6 +574,36 @@ async fn cancel_play(
     state: State<'_, Mutex<AppState>>,
 ) -> Result<(), String> {
     mpv::cancel_play(source_id, channel_id.to_string(), state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn start_recording(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<recording::RecordingInfo, String> {
+    recording::start_recording(channel, state, app)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn stop_recording(
+    recording_id: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String, String> {
+    recording::stop_recording(recording_id, state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn get_active_recordings(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<recording::RecordingInfo>, String> {
+    recording::get_active_recordings(state)
         .await
         .map_err(map_err_frontend)
 }

--- a/src-tauri/src/recording.rs
+++ b/src-tauri/src/recording.rs
@@ -1,0 +1,272 @@
+use std::{
+    io::{Read as _, Write},
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+use anyhow::{Context, Result};
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::Mutex;
+
+use crate::{
+    settings::{get_default_record_path, get_settings},
+    sql,
+    types::{ActiveRecording, AppState, Channel},
+    utils::{get_bin, sanitize},
+};
+
+const FFMPEG_BIN_NAME: &str = "ffmpeg";
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecordingInfo {
+    pub recording_id: String,
+    pub channel_id: i64,
+    pub channel_name: String,
+    pub channel_image: Option<String>,
+    pub file_path: String,
+    pub start_timestamp: u64,
+}
+
+fn make_recording_id(channel_id: i64) -> String {
+    let epoch_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("rec-{channel_id}-{epoch_ms}")
+}
+
+fn build_output_path(channel_name: &str) -> Result<String> {
+    let settings = get_settings().ok();
+    let dir = settings
+        .and_then(|s| s.recording_path)
+        .unwrap_or_else(|| get_default_record_path().unwrap_or_else(|_| "/tmp".to_string()));
+    std::fs::create_dir_all(&dir)?;
+    let sanitized = sanitize(channel_name.to_string());
+    let timestamp = Local::now().format("%Y-%m-%d-%H-%M-%S");
+    let filename = format!("{sanitized}_{timestamp}.mp4");
+    let mut path = std::path::PathBuf::from(dir);
+    path.push(filename);
+    Ok(path.to_string_lossy().to_string())
+}
+
+fn spawn_recording_ffmpeg(channel: &Channel) -> Result<(Child, String)> {
+    let url = channel.url.clone().context("no channel url")?;
+    let channel_id = channel.id.context("no channel id")?;
+    let output_path = build_output_path(&channel.name)?;
+
+    let headers = sql::get_channel_headers_by_id(channel_id)?;
+    let source_ua = channel
+        .source_id
+        .and_then(|sid| sql::get_source_from_id(sid).ok())
+        .and_then(|s| s.stream_user_agent);
+
+    let mut command = Command::new(get_bin(FFMPEG_BIN_NAME));
+
+    if let Some(headers) = &headers {
+        if let Some(referrer) = &headers.referrer {
+            command.arg("-headers");
+            command.arg(format!("Referer: {referrer}"));
+        }
+        let ua = headers.user_agent.as_ref().or(source_ua.as_ref());
+        if let Some(user_agent) = ua {
+            command.arg("-headers");
+            command.arg(format!("User-Agent: {user_agent}"));
+        }
+        if let Some(origin) = &headers.http_origin {
+            command.arg("-headers");
+            command.arg(format!("Origin: {origin}"));
+        }
+        if let Some(true) = headers.ignore_ssl {
+            command.arg("-tls_verify");
+            command.arg("0");
+        }
+    } else if let Some(ua) = &source_ua {
+        command.arg("-headers");
+        command.arg(format!("User-Agent: {ua}"));
+    }
+
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let child = command
+        .arg("-fflags")
+        .arg("+genpts+discardcorrupt")
+        .arg("-analyzeduration")
+        .arg("2000000")
+        .arg("-probesize")
+        .arg("5000000")
+        .arg("-reconnect")
+        .arg("1")
+        .arg("-reconnect_at_eof")
+        .arg("1")
+        .arg("-reconnect_streamed")
+        .arg("1")
+        .arg("-reconnect_on_network_error")
+        .arg("1")
+        .arg("-reconnect_delay_max")
+        .arg("5")
+        .arg("-i")
+        .arg(&url)
+        .arg("-c")
+        .arg("copy")
+        .arg("-movflags")
+        .arg("+faststart")
+        .arg("-y")
+        .arg(&output_path)
+        .arg("-nostats")
+        .arg("-loglevel")
+        .arg("warning")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    Ok((child, output_path))
+}
+
+pub async fn start_recording(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<RecordingInfo> {
+    let channel_id = channel.id.context("no channel id")?;
+    let recording_id = make_recording_id(channel_id);
+
+    let (child, file_path) = spawn_recording_ffmpeg(&channel)?;
+
+    let start_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let info = RecordingInfo {
+        recording_id: recording_id.clone(),
+        channel_id,
+        channel_name: channel.name.clone(),
+        channel_image: channel.image.clone(),
+        file_path,
+        start_timestamp,
+    };
+
+    let stop_signal = Arc::new(AtomicBool::new(false));
+
+    {
+        let mut guard = state.lock().await;
+        guard.active_recordings.insert(
+            recording_id.clone(),
+            ActiveRecording {
+                info: info.clone(),
+                stop_signal: stop_signal.clone(),
+            },
+        );
+    }
+
+    let _ = app.emit("recording-started", &info);
+
+    // Spawn monitor task
+    let monitor_id = recording_id.clone();
+    let monitor_info = info.clone();
+    let monitor_app = app.clone();
+    tokio::spawn(async move {
+        let state: tauri::State<'_, Mutex<AppState>> = monitor_app.state();
+        monitor_recording(child, stop_signal, monitor_id, monitor_info, state, monitor_app.clone()).await;
+    });
+
+    Ok(info)
+}
+
+async fn monitor_recording(
+    mut child: Child,
+    stop_signal: Arc<AtomicBool>,
+    recording_id: String,
+    info: RecordingInfo,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        if stop_signal.load(Ordering::Relaxed) {
+            // Graceful shutdown: write 'q' to ffmpeg's stdin so it finalizes the moov atom
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(b"q\n");
+                let _ = stdin.flush();
+                drop(stdin);
+            }
+            // Wait up to 5 seconds for ffmpeg to finalize and exit
+            let mut exited = false;
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                if let Ok(Some(_)) = child.try_wait() {
+                    exited = true;
+                    break;
+                }
+            }
+            // Force kill only as a last resort
+            if !exited {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            break;
+        }
+
+        match child.try_wait() {
+            Ok(Some(_)) => break, // process exited
+            Ok(None) => continue, // still running
+            Err(_) => break,
+        }
+    }
+
+    // Log any ffmpeg warnings/errors after exit
+    if let Some(mut stderr) = child.stderr.take() {
+        let mut buf = String::new();
+        if stderr.read_to_string(&mut buf).is_ok() && !buf.trim().is_empty() {
+            let truncated = &buf[..buf.len().min(2000)];
+            crate::log::log(format!("Recording ffmpeg output for {}: {}", info.channel_name, truncated));
+        }
+    }
+
+    {
+        let mut guard = state.lock().await;
+        guard.active_recordings.remove(&recording_id);
+    }
+
+    let _ = app.emit("recording-stopped", &info);
+}
+
+pub async fn stop_recording(
+    recording_id: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String> {
+    let guard = state.lock().await;
+    let recording = guard
+        .active_recordings
+        .get(&recording_id)
+        .context("recording not found")?;
+    recording.stop_signal.store(true, Ordering::Relaxed);
+    let path = recording.info.file_path.clone();
+    Ok(path)
+}
+
+pub async fn get_active_recordings(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<RecordingInfo>> {
+    let guard = state.lock().await;
+    let recordings: Vec<RecordingInfo> = guard
+        .active_recordings
+        .values()
+        .map(|r| r.info.clone())
+        .collect();
+    Ok(recordings)
+}

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -175,6 +175,12 @@ pub struct EPGNotify {
     pub channel_name: String,
 }
 
+#[derive(Debug)]
+pub struct ActiveRecording {
+    pub info: crate::recording::RecordingInfo,
+    pub stop_signal: Arc<AtomicBool>,
+}
+
 #[derive(Debug, Default)]
 pub struct AppState {
     pub notify_stop: Arc<AtomicBool>,
@@ -182,6 +188,7 @@ pub struct AppState {
     pub restream_stop_signal: Arc<AtomicBool>,
 
     pub play_stop: HashMap<i64, IndexMap<String, CancellationToken>>,
+    pub active_recordings: HashMap<String, ActiveRecording>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/src/app/channel-tile/channel-tile.component.html
+++ b/src/app/channel-tile/channel-tile.component.html
@@ -44,7 +44,11 @@
         *ngIf="alreadyHidden">Unhide</ng-container>
       <ng-container *ngIf="!alreadyHidden">Hide</ng-container>
     </button>
-    <button [hidden]="!isLivestream()" mat-menu-item (click)="record()">Record</button>
+    <button [hidden]="!isLivestream()" mat-menu-item (click)="record()" [disabled]="isRecordingBusy()">
+      <ng-container *ngIf="isRecordingBusy()">Working...</ng-container>
+      <ng-container *ngIf="!isRecordingBusy() && isChannelRecording()">Stop Recording</ng-container>
+      <ng-container *ngIf="!isRecordingBusy() && !isChannelRecording()">Record</ng-container>
+    </button>
     <button [hidden]="!isMovie() || downloading" mat-menu-item (click)="downloadVod()">
       Download
     </button>

--- a/src/app/channel-tile/channel-tile.component.ts
+++ b/src/app/channel-tile/channel-tile.component.ts
@@ -25,8 +25,9 @@ import { DownloadService } from "../download.service";
 import { Download } from "../models/download";
 import { Subscription, take } from "rxjs";
 import { save } from "@tauri-apps/plugin-dialog";
-import { CHANNEL_EXTENSION, GROUP_EXTENSION, RECORD_EXTENSION } from "../models/extensions";
-import { getDateFormatted, getExtension, sanitizeFileName } from "../utils";
+import { CHANNEL_EXTENSION, GROUP_EXTENSION } from "../models/extensions";
+import { getExtension, sanitizeFileName } from "../utils";
+import { RecordingService } from "../recording.service";
 import { NodeType, fromMediaType } from "../models/nodeType";
 
 import { ViewMode } from "../models/viewMode";
@@ -45,6 +46,7 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
     private el: ElementRef,
     private renderer: Renderer2,
     private download: DownloadService,
+    public recording: RecordingService,
   ) { }
   @Input() channel?: Channel;
   @Input() id!: number;
@@ -77,7 +79,7 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
     this.renderer.setStyle(element, "background", background);
   }
 
-  async click(record = false) {
+  async click() {
     if (this.starting === true) {
       try {
         await invoke("cancel_play", { sourceId: this.channel?.source_id, channelId: this.channel?.id });
@@ -114,19 +116,10 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
       });
       return;
     }
-    let file = undefined;
-    if (record && (this.memory.IsContainer || this.memory.AlwaysAskSave)) {
-      file = await save({
-        canCreateDirectories: true,
-        title: "Select where to save recording",
-        defaultPath: `${sanitizeFileName(this.channel?.name!)}_${getDateFormatted()}${RECORD_EXTENSION}`,
-      });
-      if (!file) return;
-    }
     this.starting = true;
     this.memory.SetFocus.next(this.id);
     try {
-      await invoke("play", { channel: this.channel, record: record, recordPath: file });
+      await invoke("play", { channel: this.channel, record: false, recordPath: null });
     } catch (e) {
       this.error.handleError(e);
     }
@@ -211,7 +204,16 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
   }
 
   async record() {
-    await this.click(true);
+    if (!this.channel) return;
+    await this.recording.toggleRecording(this.channel);
+  }
+
+  isChannelRecording(): boolean {
+    return !!this.channel?.id && this.recording.isRecording(this.channel.id);
+  }
+
+  isRecordingBusy(): boolean {
+    return !!this.channel?.id && this.recording.isBusy(this.channel.id);
   }
 
   isMovie() {

--- a/src/app/models/recording.ts
+++ b/src/app/models/recording.ts
@@ -1,0 +1,8 @@
+export interface RecordingInfo {
+  recording_id: string;
+  channel_id: number;
+  channel_name: string;
+  channel_image?: string;
+  file_path: string;
+  start_timestamp: number;
+}

--- a/src/app/recording.service.ts
+++ b/src/app/recording.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, OnDestroy } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, UnlistenFn } from "@tauri-apps/api/event";
+import { ToastrService } from "ngx-toastr";
+import { ErrorService } from "./error.service";
+import { RecordingInfo } from "./models/recording";
+import { Channel } from "./models/channel";
+
+@Injectable({
+  providedIn: "root",
+})
+export class RecordingService implements OnDestroy {
+  recordings$ = new BehaviorSubject<Map<string, RecordingInfo>>(new Map());
+  currentTime$ = new BehaviorSubject<number>(Date.now() / 1000);
+  private busyChannels = new Set<number>();
+
+  private timerInterval: ReturnType<typeof setInterval> | null = null;
+  private unlistenStarted?: UnlistenFn;
+  private unlistenStopped?: UnlistenFn;
+
+  constructor(
+    private toastr: ToastrService,
+    private error: ErrorService,
+  ) {
+    this.initListeners();
+    this.recoverState();
+  }
+
+  private async initListeners() {
+    this.unlistenStarted = await listen<RecordingInfo>("recording-started", (event) => {
+      const info = event.payload;
+      const map = new Map(this.recordings$.value);
+      map.set(info.recording_id, info);
+      this.recordings$.next(map);
+      this.toastr.success(`Recording started: ${info.channel_name}`);
+      this.ensureTimer();
+    });
+
+    this.unlistenStopped = await listen<RecordingInfo>("recording-stopped", (event) => {
+      const info = event.payload;
+      const map = new Map(this.recordings$.value);
+      map.delete(info.recording_id);
+      this.recordings$.next(map);
+      const filename = info.file_path.split(/[\\/]/).pop() ?? info.file_path;
+      this.toastr.success(`Recording saved: ${filename}`);
+      if (map.size === 0) this.stopTimer();
+    });
+  }
+
+  private async recoverState() {
+    try {
+      const recordings = await invoke<RecordingInfo[]>("get_active_recordings");
+      if (recordings.length > 0) {
+        const map = new Map<string, RecordingInfo>();
+        for (const r of recordings) {
+          map.set(r.recording_id, r);
+        }
+        this.recordings$.next(map);
+        this.ensureTimer();
+      }
+    } catch (_) {}
+  }
+
+  private ensureTimer() {
+    if (this.timerInterval) return;
+    this.timerInterval = setInterval(() => {
+      this.currentTime$.next(Date.now() / 1000);
+    }, 1000);
+  }
+
+  private stopTimer() {
+    if (this.timerInterval) {
+      clearInterval(this.timerInterval);
+      this.timerInterval = null;
+    }
+  }
+
+  isBusy(channelId: number): boolean {
+    return this.busyChannels.has(channelId);
+  }
+
+  async startRecording(channel: Channel) {
+    try {
+      await invoke<RecordingInfo>("start_recording", { channel });
+    } catch (e) {
+      this.error.handleError(e, "Failed to start recording");
+    }
+  }
+
+  async stopRecording(recordingId: string) {
+    const rec = this.recordings$.value.get(recordingId);
+    if (rec && this.busyChannels.has(rec.channel_id)) return;
+    if (rec) this.busyChannels.add(rec.channel_id);
+    try {
+      await invoke<string>("stop_recording", { recordingId });
+    } catch (e) {
+      this.error.handleError(e, "Failed to stop recording");
+    } finally {
+      if (rec) this.busyChannels.delete(rec.channel_id);
+    }
+  }
+
+  isRecording(channelId: number): boolean {
+    for (const r of this.recordings$.value.values()) {
+      if (r.channel_id === channelId) return true;
+    }
+    return false;
+  }
+
+  getRecordingForChannel(channelId: number): RecordingInfo | undefined {
+    for (const r of this.recordings$.value.values()) {
+      if (r.channel_id === channelId) return r;
+    }
+    return undefined;
+  }
+
+  async toggleRecording(channel: Channel) {
+    if (!channel.id || this.busyChannels.has(channel.id)) return;
+    this.busyChannels.add(channel.id);
+    try {
+      const existing = this.getRecordingForChannel(channel.id);
+      if (existing) {
+        await this.stopRecording(existing.recording_id);
+      } else {
+        await this.startRecording(channel);
+      }
+    } finally {
+      this.busyChannels.delete(channel.id!);
+    }
+  }
+
+  formatElapsed(startTimestamp: number, now: number): string {
+    const elapsed = Math.max(0, Math.floor(now - startTimestamp));
+    const h = Math.floor(elapsed / 3600);
+    const m = Math.floor((elapsed % 3600) / 60);
+    const s = elapsed % 60;
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+    }
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  }
+
+  ngOnDestroy() {
+    this.stopTimer();
+    this.unlistenStarted?.();
+    this.unlistenStopped?.();
+  }
+}


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
Complete recording system with Rust backend and Angular frontend integration:

- **Backend** (`recording.rs`): Spawn ffmpeg to record livestreams to MP4. Graceful shutdown via stdin `q` (preserves moov atom), fallback SIGKILL after 5s. Stderr capture for diagnostics. Active recordings tracked in AppState with atomic stop signals.
- **Frontend** (`recording.service.ts`): Tauri event listeners for start/stop, BehaviorSubject state management, busy-channel guard against race conditions, elapsed time timer, state recovery on restart.
- **Integration**: Channel tile recording button shows Working/Stop Recording/Record states. New Tauri commands: `start_recording`, `stop_recording`, `get_active_recordings`. ExitRequested handler signals all recordings to stop on app close.

### Files
- **New**: `src-tauri/src/recording.rs`, `src/app/recording.service.ts`, `src/app/models/recording.ts`
- **Modified**: `src-tauri/src/lib.rs`, `src-tauri/src/types.rs`, `src/app/channel-tile/channel-tile.component.ts`, `src/app/channel-tile/channel-tile.component.html`

## Test plan
- [ ] Start recording a livestream, verify ffmpeg spawns and MP4 file grows
- [ ] Stop recording, verify file is playable (moov atom intact)
- [ ] Spam-click record button, verify no duplicate ffmpeg processes
- [ ] Close app while recording, verify ffmpeg is killed (no orphans)
- [ ] Reopen app, verify active recording state is recovered