### PR TITLE
feat: inline player with Web/MPV engine selection

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -45,13 +45,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
+                  "maximumWarning": "2mb",
                   "maximumError": "10mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "10kb",
+                  "maximumError": "20kb"
                 }
               ],
               "optimization": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tauri-apps/plugin-dialog": "^2.4.2",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-shell": "^2.3.3",
+    "hls.js": "^1.5.0",
     "ng-keyboard-shortcuts": "^13.0.8",
     "ngx-toastr": "^19.0.0",
     "rxjs": "~7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,20 +45,23 @@ importers:
         specifier: ^2.11.8
         version: 2.11.8
       '@tauri-apps/api':
-        specifier: ^2.6.0
-        version: 2.8.0
+        specifier: ^2.9.0
+        version: 2.10.1
       '@tauri-apps/plugin-clipboard-manager':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.3.0
-        version: 2.4.0
+        specifier: ^2.4.2
+        version: 2.6.0
       '@tauri-apps/plugin-notification':
-        specifier: ^2.3.0
-        version: 2.3.1
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-shell':
-        specifier: ^2.3.0
-        version: 2.3.1
+        specifier: ^2.3.3
+        version: 2.3.5
+      hls.js:
+        specifier: ^1.5.0
+        version: 1.6.15
       ng-keyboard-shortcuts:
         specifier: ^13.0.8
         version: 13.0.8(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(@angular/platform-browser@17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(rxjs@7.8.2)
@@ -88,8 +91,8 @@ importers:
         specifier: ^17.3.0
         version: 17.3.12(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))
       '@tauri-apps/cli':
-        specifier: ^2.2.2
-        version: 2.8.4
+        specifier: ^2.9.4
+        version: 2.10.1
       '@types/jasmine':
         specifier: ~5.1.0
         version: 5.1.12
@@ -1494,91 +1497,91 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
-  '@tauri-apps/api@2.8.0':
-    resolution: {integrity: sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==}
+  '@tauri-apps/api@2.10.1':
+    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
-  '@tauri-apps/cli-darwin-arm64@2.8.4':
-    resolution: {integrity: sha512-BKu8HRkYV01SMTa7r4fLx+wjgtRK8Vep7lmBdHDioP6b8XH3q2KgsAyPWfEZaZIkZ2LY4SqqGARaE9oilNe0oA==}
+  '@tauri-apps/cli-darwin-arm64@2.10.1':
+    resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.8.4':
-    resolution: {integrity: sha512-imb9PfSd/7G6VAO7v1bQ2A3ZH4NOCbhGJFLchxzepGcXf9NKkfun157JH9mko29K6sqAwuJ88qtzbKCbWJTH9g==}
+  '@tauri-apps/cli-darwin-x64@2.10.1':
+    resolution: {integrity: sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.8.4':
-    resolution: {integrity: sha512-Ml215UnDdl7/fpOrF1CNovym/KjtUbCuPgrcZ4IhqUCnhZdXuphud/JT3E8X97Y03TZ40Sjz8raXYI2ET0exzw==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+    resolution: {integrity: sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.8.4':
-    resolution: {integrity: sha512-pbcgBpMyI90C83CxE5REZ9ODyIlmmAPkkJXtV398X3SgZEIYy5TACYqlyyv2z5yKgD8F8WH4/2fek7+jH+ZXAw==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+    resolution: {integrity: sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.8.4':
-    resolution: {integrity: sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==}
+  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+    resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.8.4':
-    resolution: {integrity: sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+    resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.8.4':
-    resolution: {integrity: sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==}
+  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+    resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-x64-musl@2.8.4':
-    resolution: {integrity: sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==}
+  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+    resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.8.4':
-    resolution: {integrity: sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+    resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.8.4':
-    resolution: {integrity: sha512-yj7WDxkL1t9Uzr2gufQ1Hl7hrHuFKTNEOyascbc109EoiAqCp0tgZ2IykQqOZmZOHU884UAWI1pVMqBhS/BfhA==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+    resolution: {integrity: sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.8.4':
-    resolution: {integrity: sha512-XuvGB4ehBdd7QhMZ9qbj/8icGEatDuBNxyYHbLKsTYh90ggUlPa/AtaqcC1Fo69lGkTmq9BOKrs1aWSi7xDonA==}
+  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+    resolution: {integrity: sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.8.4':
-    resolution: {integrity: sha512-ejUZBzuQRcjFV+v/gdj/DcbyX/6T4unZQjMSBZwLzP/CymEjKcc2+Fc8xTORThebHDUvqoXMdsCZt8r+hyN15g==}
+  '@tauri-apps/cli@2.10.1':
+    resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-clipboard-manager@2.3.0':
-    resolution: {integrity: sha512-81NOBA2P+OTY8RLkBwyl9ZR/0CeggLub4F6zxcxUIfFOAqtky7J61+K/MkH2SC1FMxNBxrX0swDuKvkjkHadlA==}
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
-  '@tauri-apps/plugin-dialog@2.4.0':
-    resolution: {integrity: sha512-OvXkrEBfWwtd8tzVCEXIvRfNEX87qs2jv6SqmVPiHcJjBhSF/GUvjqUNIDmKByb5N8nvDqVUM7+g1sXwdC/S9w==}
+  '@tauri-apps/plugin-dialog@2.6.0':
+    resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
 
-  '@tauri-apps/plugin-notification@2.3.1':
-    resolution: {integrity: sha512-7gqgfANSREKhh35fY1L4j3TUjUdePmU735FYDqRGeIf8nMXWpcx6j4FhN9/4nYz+m0mv79DCTPLqIPTySggGgg==}
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
-  '@tauri-apps/plugin-shell@2.3.1':
-    resolution: {integrity: sha512-jjs2WGDO/9z2pjNlydY/F5yYhNsscv99K5lCmU5uKjsVvQ3dRlDhhtVYoa4OLDmktLtQvgvbQjCFibMl6tgGfw==}
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
@@ -2566,6 +2569,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -4293,7 +4299,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1703.17(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0))(webpack@5.94.0)
+      '@angular-devkit/build-webpack': 0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0))(webpack@5.94.0(esbuild@0.20.1))
       '@angular-devkit/core': 17.3.17(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5)
       '@babel/core': 7.26.10
@@ -4306,16 +4312,16 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/runtime': 7.26.10
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.94.0)
+      '@ngtools/webpack': 17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.94.0(esbuild@0.20.1))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.20(@types/node@24.8.1)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
-      babel-loader: 9.1.3(@babel/core@7.26.10)(webpack@5.94.0)
+      babel-loader: 9.1.3(@babel/core@7.26.10)(webpack@5.94.0(esbuild@0.20.1))
       babel-plugin-istanbul: 6.1.1
       browserslist: 4.26.3
-      copy-webpack-plugin: 11.0.0(webpack@5.94.0)
+      copy-webpack-plugin: 11.0.0(webpack@5.94.0(esbuild@0.20.1))
       critters: 0.0.22
-      css-loader: 6.10.0(webpack@5.94.0)
+      css-loader: 6.10.0(webpack@5.94.0(esbuild@0.20.1))
       esbuild-wasm: 0.20.1
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.8(@types/express@4.17.23)
@@ -4324,11 +4330,11 @@ snapshots:
       jsonc-parser: 3.2.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 11.1.0(less@4.2.0)(webpack@5.94.0)
-      license-webpack-plugin: 4.0.2(webpack@5.94.0)
+      less-loader: 11.1.0(less@4.2.0)(webpack@5.94.0(esbuild@0.20.1))
+      license-webpack-plugin: 4.0.2(webpack@5.94.0(esbuild@0.20.1))
       loader-utils: 3.2.1
       magic-string: 0.30.8
-      mini-css-extract-plugin: 2.8.1(webpack@5.94.0)
+      mini-css-extract-plugin: 2.8.1(webpack@5.94.0(esbuild@0.20.1))
       mrmime: 2.0.0
       open: 8.4.2
       ora: 5.4.1
@@ -4336,13 +4342,13 @@ snapshots:
       picomatch: 4.0.1
       piscina: 4.4.0
       postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.94.0)
+      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.94.0(esbuild@0.20.1))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.71.1
-      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.94.0)
+      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.94.0(esbuild@0.20.1))
       semver: 7.6.0
-      source-map-loader: 5.0.0(webpack@5.94.0)
+      source-map-loader: 5.0.0(webpack@5.94.0(esbuild@0.20.1))
       source-map-support: 0.5.21
       terser: 5.29.1
       tree-kill: 1.2.2
@@ -4351,10 +4357,10 @@ snapshots:
       vite: 5.4.20(@types/node@24.8.1)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
       watchpack: 2.4.0
       webpack: 5.94.0(esbuild@0.20.1)
-      webpack-dev-middleware: 6.1.2(webpack@5.94.0)
+      webpack-dev-middleware: 6.1.2(webpack@5.94.0(esbuild@0.20.1))
       webpack-dev-server: 4.15.1(webpack@5.94.0)
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.94.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.94.0(esbuild@0.20.1))
     optionalDependencies:
       '@angular/localize': 17.3.12(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))
       esbuild: 0.20.1
@@ -4378,7 +4384,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0))(webpack@5.94.0)':
+  '@angular-devkit/build-webpack@0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0))(webpack@5.94.0(esbuild@0.20.1))':
     dependencies:
       '@angular-devkit/architect': 0.1703.17(chokidar@3.6.0)
       rxjs: 7.8.1
@@ -6067,7 +6073,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@ngtools/webpack@17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.94.0)':
+  '@ngtools/webpack@17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.94.0(esbuild@0.20.1))':
     dependencies:
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.4.5)
       typescript: 5.4.5
@@ -6262,70 +6268,70 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@tauri-apps/api@2.8.0': {}
+  '@tauri-apps/api@2.10.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.8.4':
+  '@tauri-apps/cli-darwin-arm64@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.8.4':
+  '@tauri-apps/cli-darwin-x64@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.8.4':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.8.4':
+  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.8.4':
+  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.8.4':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.8.4':
+  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.8.4':
+  '@tauri-apps/cli-linux-x64-musl@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.8.4':
+  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.8.4':
+  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.8.4':
+  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
     optional: true
 
-  '@tauri-apps/cli@2.8.4':
+  '@tauri-apps/cli@2.10.1':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.8.4
-      '@tauri-apps/cli-darwin-x64': 2.8.4
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.8.4
-      '@tauri-apps/cli-linux-arm64-gnu': 2.8.4
-      '@tauri-apps/cli-linux-arm64-musl': 2.8.4
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.8.4
-      '@tauri-apps/cli-linux-x64-gnu': 2.8.4
-      '@tauri-apps/cli-linux-x64-musl': 2.8.4
-      '@tauri-apps/cli-win32-arm64-msvc': 2.8.4
-      '@tauri-apps/cli-win32-ia32-msvc': 2.8.4
-      '@tauri-apps/cli-win32-x64-msvc': 2.8.4
+      '@tauri-apps/cli-darwin-arm64': 2.10.1
+      '@tauri-apps/cli-darwin-x64': 2.10.1
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.10.1
+      '@tauri-apps/cli-linux-arm64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-arm64-musl': 2.10.1
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-x64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-x64-musl': 2.10.1
+      '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
+      '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
+      '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
-  '@tauri-apps/plugin-clipboard-manager@2.3.0':
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
-      '@tauri-apps/api': 2.8.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-dialog@2.4.0':
+  '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
-      '@tauri-apps/api': 2.8.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-notification@2.3.1':
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
-      '@tauri-apps/api': 2.8.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-shell@2.3.1':
+  '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
-      '@tauri-apps/api': 2.8.0
+      '@tauri-apps/api': 2.10.1
 
   '@tufjs/canonical-json@2.0.0': {}
 
@@ -6643,7 +6649,7 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.1.3(@babel/core@7.26.10)(webpack@5.94.0):
+  babel-loader@9.1.3(@babel/core@7.26.10)(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
@@ -6912,7 +6918,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@11.0.0(webpack@5.94.0):
+  copy-webpack-plugin@11.0.0(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -6958,7 +6964,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.10.0(webpack@5.94.0):
+  css-loader@6.10.0(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.35)
       postcss: 8.4.35
@@ -7477,6 +7483,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hls.js@1.6.15: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -7844,7 +7852,7 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  less-loader@11.1.0(less@4.2.0)(webpack@5.94.0):
+  less-loader@11.1.0(less@4.2.0)(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       klona: 2.0.6
       less: 4.2.0
@@ -7864,7 +7872,7 @@ snapshots:
       needle: 3.3.1
       source-map: 0.6.1
 
-  license-webpack-plugin@4.0.2(webpack@5.94.0):
+  license-webpack-plugin@4.0.2(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -7985,7 +7993,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mini-css-extract-plugin@2.8.1(webpack@5.94.0):
+  mini-css-extract-plugin@2.8.1(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
@@ -8351,7 +8359,7 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.94.0):
+  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.7
@@ -8612,7 +8620,7 @@ snapshots:
 
   safevalues@0.3.4: {}
 
-  sass-loader@14.1.1(sass@1.71.1)(webpack@5.94.0):
+  sass-loader@14.1.1(sass@1.71.1)(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -8825,7 +8833,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.94.0):
+  source-map-loader@5.0.0(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -9109,7 +9117,7 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.94.0(esbuild@0.20.1)
 
-  webpack-dev-middleware@6.1.2(webpack@5.94.0):
+  webpack-dev-middleware@6.1.2(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -9167,7 +9175,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.94.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.94.0(esbuild@0.20.1)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.94.0(esbuild@0.20.1)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, Manager, State};
 use tokio::sync::Mutex;
 use types::{
     AppState, Channel, CustomChannel, CustomChannelExtraData, EPG, EPGNotify, Filters, Group,
-    IdName, NetworkInfo, Settings, Source,
+    IdName, NetworkInfo, Settings, Source, StreamInfo,
 };
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use {
@@ -19,6 +19,7 @@ use {
 
 pub mod bulk_action_type;
 pub mod epg;
+pub mod local_player;
 pub mod log;
 pub mod m3u;
 pub mod media_type;
@@ -113,6 +114,9 @@ pub fn run() {
             hide_channel,
             hide_group,
             remove_from_history,
+            get_stream_info,
+            start_local_stream,
+            stop_local_stream,
         ])
         .setup(|app| {
             app.manage(Mutex::new(AppState {
@@ -147,6 +151,14 @@ pub fn run() {
                 let window = _app.get_webview_window("main").expect("no main window");
                 let _ = window.show();
                 let _ = window.set_focus();
+            }
+            tauri::RunEvent::ExitRequested { .. } => {
+                let state: State<Mutex<AppState>> = _app.state();
+                if let Ok(state) = state.try_lock() {
+                    state.notify_stop.store(true, Ordering::Relaxed);
+                    state.restream_stop_signal.store(true, Ordering::Relaxed);
+                    state.local_player_stop.store(true, Ordering::Relaxed);
+                }
             }
             _ => {}
         });
@@ -558,6 +570,28 @@ async fn cancel_play(
     state: State<'_, Mutex<AppState>>,
 ) -> Result<(), String> {
     mpv::cancel_play(source_id, channel_id.to_string(), state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command(async)]
+fn get_stream_info(channel: Channel) -> Result<StreamInfo, String> {
+    local_player::get_stream_info(&channel).map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn start_local_stream(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String, String> {
+    local_player::start_local_stream(channel, state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn stop_local_stream(state: State<'_, Mutex<AppState>>) -> Result<(), String> {
+    local_player::stop_local_stream(state)
         .await
         .map_err(map_err_frontend)
 }

--- a/src-tauri/src/local_player.rs
+++ b/src-tauri/src/local_player.rs
@@ -1,0 +1,214 @@
+use std::{
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+use anyhow::{Context, Result};
+use tauri::State;
+use warp::Filter;
+use tokio::{
+    fs,
+    sync::{
+        Mutex,
+        oneshot::{self, Sender},
+    },
+};
+
+use crate::{
+    sql,
+    types::{AppState, Channel, StreamInfo},
+    utils::get_bin,
+};
+
+const FFMPEG_BIN_NAME: &str = "ffmpeg";
+const DEFAULT_LOCAL_PLAYER_PORT: u16 = 9321;
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+pub fn get_stream_info(channel: &Channel) -> Result<StreamInfo> {
+    let url = channel.url.clone().context("no channel url")?;
+    let channel_id = channel.id.context("no channel id")?;
+    let headers = sql::get_channel_headers_by_id(channel_id)?;
+
+    // Also check if the source has a stream_user_agent set
+    let source_has_ua = channel
+        .source_id
+        .and_then(|sid| sql::get_source_from_id(sid).ok())
+        .and_then(|s| s.stream_user_agent)
+        .is_some();
+
+    let has_custom_headers = source_has_ua
+        || headers
+            .as_ref()
+            .map(|h| {
+                h.referrer.is_some()
+                    || h.user_agent.is_some()
+                    || h.http_origin.is_some()
+                    || h.ignore_ssl == Some(true)
+            })
+            .unwrap_or(false);
+    let url_path = url.split('?').next().unwrap_or(&url);
+    let is_hls = url_path.ends_with(".m3u8") || url_path.ends_with(".m3u");
+    Ok(StreamInfo {
+        url,
+        has_custom_headers,
+        is_hls,
+    })
+}
+
+fn start_ffmpeg(channel: Channel, cache_dir: PathBuf) -> Result<Child> {
+    let headers = sql::get_channel_headers_by_id(channel.id.context("no channel id")?)?;
+    let mut playlist_path = cache_dir;
+    playlist_path.push("stream.m3u8");
+    let playlist_str = playlist_path.to_string_lossy().to_string();
+    let mut command = Command::new(get_bin(FFMPEG_BIN_NAME));
+    if let Some(headers) = headers {
+        if let Some(referrer) = headers.referrer {
+            command.arg("-headers");
+            command.arg(format!("Referer: {referrer}"));
+        }
+        if let Some(user_agent) = headers.user_agent {
+            command.arg("-headers");
+            command.arg(format!("User-Agent: {user_agent}"));
+        }
+        if let Some(origin) = headers.http_origin {
+            command.arg("-headers");
+            command.arg(format!("Origin: {origin}"));
+        }
+        if let Some(ignore_ssl) = headers.ignore_ssl {
+            if ignore_ssl {
+                command.arg("-tls_verify");
+                command.arg("0");
+            }
+        }
+    }
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+    let child = command
+        .arg("-fflags")
+        .arg("+genpts+discardcorrupt")
+        .arg("-analyzeduration")
+        .arg("2000000")
+        .arg("-probesize")
+        .arg("5000000")
+        .arg("-i")
+        .arg(channel.url.context("no channel url")?)
+        .arg("-c")
+        .arg("copy")
+        .arg("-f")
+        .arg("hls")
+        .arg("-hls_time")
+        .arg("2")
+        .arg("-hls_list_size")
+        .arg("10")
+        .arg("-hls_flags")
+        .arg("delete_segments+append_list")
+        .arg("-reconnect")
+        .arg("1")
+        .arg("-reconnect_at_eof")
+        .arg("1")
+        .arg("-reconnect_streamed")
+        .arg("1")
+        .arg("-reconnect_on_network_error")
+        .arg("1")
+        .arg("-reconnect_delay_max")
+        .arg("5")
+        .arg(playlist_str)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    Ok(child)
+}
+
+async fn start_web_server(
+    cache_dir: PathBuf,
+    port: u16,
+) -> Result<(Sender<bool>, tokio::task::JoinHandle<()>)> {
+    let file_server = warp::fs::dir(cache_dir);
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_methods(vec!["GET", "HEAD", "OPTIONS"])
+        .allow_headers(vec!["Range", "Content-Type"]);
+    let routes = file_server.with(cors);
+    let (tx, rx) = oneshot::channel::<bool>();
+    let (_, server) =
+        warp::serve(routes).bind_with_graceful_shutdown(([127, 0, 0, 1], port), async {
+            rx.await.ok();
+        });
+    let handle = tokio::spawn(server);
+    Ok((tx, handle))
+}
+
+fn get_local_player_folder() -> Result<PathBuf> {
+    let mut path = directories::ProjectDirs::from("dev", "fredol", "open-tv")
+        .context("can't find project folder")?
+        .cache_dir()
+        .to_owned();
+    path.push("local_player");
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    Ok(path)
+}
+
+async fn clean_cache(dir: &std::path::Path) -> Result<()> {
+    if dir.exists() {
+        fs::remove_dir_all(dir).await?;
+    }
+    fs::create_dir_all(dir).await?;
+    Ok(())
+}
+
+pub async fn start_local_stream(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String> {
+    let stop = {
+        let s = state.lock().await;
+        s.local_player_stop.clone()
+    };
+    stop.store(false, std::sync::atomic::Ordering::Relaxed);
+
+    let cache_dir = get_local_player_folder()?;
+    clean_cache(&cache_dir).await?;
+
+    let port = DEFAULT_LOCAL_PLAYER_PORT;
+    {
+        let mut s = state.lock().await;
+        s.local_player_port = Some(port);
+    }
+
+    let mut ffmpeg_child = start_ffmpeg(channel, cache_dir.clone())?;
+    let (web_tx, web_handle) = start_web_server(cache_dir, port).await?;
+
+    let local_url = format!("http://127.0.0.1:{port}/stream.m3u8");
+
+    tokio::spawn(async move {
+        while !stop.load(std::sync::atomic::Ordering::Relaxed)
+            && ffmpeg_child
+                .try_wait()
+                .map(|opt| opt.is_none())
+                .unwrap_or(true)
+            && !web_handle.is_finished()
+        {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        let _ = ffmpeg_child.kill();
+        let _ = web_tx.send(true);
+        let _ = ffmpeg_child.wait();
+        let _ = web_handle.await;
+    });
+
+    Ok(local_url)
+}
+
+pub async fn stop_local_stream(state: State<'_, Mutex<AppState>>) -> Result<()> {
+    let s = state.lock().await;
+    s.local_player_stop
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_SORT: &str = "defaultSort";
 pub const ENABLE_HWDEC: &str = "enableHWDEC";
 pub const ALWAYS_ASK_SAVE: &str = "alwaysAskSave";
 pub const ENABLE_GPU: &str = "enableGPU";
+pub const PLAYER_ENGINE: &str = "playerEngine";
 
 pub fn get_settings() -> Result<Settings> {
     let map = sql::get_settings()?;
@@ -39,12 +40,13 @@ pub fn get_settings() -> Result<Settings> {
         enable_hwdec: map.get(ENABLE_HWDEC).and_then(|s| s.parse().ok()),
         always_ask_save: map.get(ALWAYS_ASK_SAVE).and_then(|s| s.parse().ok()),
         enable_gpu: map.get(ENABLE_GPU).and_then(|s| s.parse().ok()),
+        player_engine: map.get(PLAYER_ENGINE).and_then(|s| s.parse().ok()),
     };
     Ok(settings)
 }
 
 pub fn update_settings(settings: Settings) -> Result<()> {
-    let mut map: HashMap<String, Option<String>> = HashMap::with_capacity(13);
+    let mut map: HashMap<String, Option<String>> = HashMap::with_capacity(14);
 
     map.insert(MPV_PARAMS.to_string(), settings.mpv_params);
 
@@ -89,6 +91,9 @@ pub fn update_settings(settings: Settings) -> Result<()> {
     }
     if let Some(gpu) = settings.enable_gpu {
         map.insert(ENABLE_GPU.to_string(), Some(gpu.to_string()));
+    }
+    if let Some(engine) = settings.player_engine {
+        map.insert(PLAYER_ENGINE.to_string(), Some(engine.to_string()));
     }
     sql::update_settings(map)?;
     Ok(())

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -83,6 +83,7 @@ pub struct Settings {
     pub enable_hwdec: Option<bool>,
     pub always_ask_save: Option<bool>,
     pub enable_gpu: Option<bool>,
+    pub player_engine: Option<u8>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
@@ -175,11 +176,19 @@ pub struct EPGNotify {
     pub channel_name: String,
 }
 
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct StreamInfo {
+    pub url: String,
+    pub has_custom_headers: bool,
+    pub is_hls: bool,
+}
 #[derive(Debug, Default)]
 pub struct AppState {
     pub notify_stop: Arc<AtomicBool>,
     pub thread_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
     pub restream_stop_signal: Arc<AtomicBool>,
+    pub local_player_stop: Arc<AtomicBool>,
+    pub local_player_port: Option<u16>,
 
     pub play_stop: HashMap<i64, IndexMap<String, CancellationToken>>,
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
+<app-inline-player></app-inline-player>
 <router-outlet></router-outlet>
 <app-download-manager *ngIf="showDownloadManager()"></app-download-manager>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,15 +1,36 @@
-import { Component, HostListener } from "@angular/core";
+import { Component, HostListener, OnDestroy, OnInit } from "@angular/core";
+import { Subscription } from "rxjs";
 import { DownloadService } from "./download.service";
+import { MemoryService } from "./memory.service";
+import { PlayerState } from "./models/playerState";
 
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html",
   styleUrl: "./app.component.css",
 })
-export class AppComponent {
+export class AppComponent implements OnInit, OnDestroy {
   title = "open-tv";
+  playerState: PlayerState = PlayerState.Closed;
+  private subscriptions: Subscription[] = [];
 
-  constructor(private download: DownloadService) {}
+  constructor(
+    private download: DownloadService,
+    public memory: MemoryService,
+  ) {}
+
+  ngOnInit() {
+    // Subscribe to PlayerState for inline player layout
+    this.subscriptions.push(
+      this.memory.PlayerState.subscribe((state) => {
+        this.playerState = state;
+      }),
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  }
 
   @HostListener("document:contextmenu", ["$event"])
   onRightClick(event: MouseEvent) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { SortItemComponent } from './home/sort-button/sort-item/sort-item.compon
 import { DownloadManagerComponent } from './download-manager/download-manager.component';
 
 import { TimeAgoPipe } from "./pipes/time-ago.pipe";
+import { InlinePlayerComponent } from './inline-player/inline-player.component';
 
 @NgModule({
   declarations: [
@@ -60,6 +61,7 @@ import { TimeAgoPipe } from "./pipes/time-ago.pipe";
     SortButtonComponent,
     SortItemComponent,
     DownloadManagerComponent,
+    InlinePlayerComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/channel-tile/channel-tile.component.ts
+++ b/src/app/channel-tile/channel-tile.component.ts
@@ -28,6 +28,8 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { CHANNEL_EXTENSION, GROUP_EXTENSION, RECORD_EXTENSION } from "../models/extensions";
 import { getDateFormatted, getExtension, sanitizeFileName } from "../utils";
 import { NodeType, fromMediaType } from "../models/nodeType";
+import { PlayerEngine } from "../models/playerEngine";
+import { PlayerState } from "../models/playerState";
 
 import { ViewMode } from "../models/viewMode";
 
@@ -81,6 +83,7 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
     if (this.starting === true) {
       try {
         await invoke("cancel_play", { sourceId: this.channel?.source_id, channelId: this.channel?.id });
+        this.memory.NowPlaying.next(null);
       } catch (e) {
         this.error.handleError(e);
       }
@@ -114,17 +117,21 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
       });
       return;
     }
-    let file = undefined;
-    if (record && (this.memory.IsContainer || this.memory.AlwaysAskSave)) {
-      file = await save({
-        canCreateDirectories: true,
-        title: "Select where to save recording",
-        defaultPath: `${sanitizeFileName(this.channel?.name!)}_${getDateFormatted()}${RECORD_EXTENSION}`,
-      });
-      if (!file) return;
+    const engine = this.memory.PlayerEngine.value ?? PlayerEngine.Web;
+
+    // Web / EmbeddedMpv: set NowPlaying and let InlinePlayerComponent handle it
+    if (engine === PlayerEngine.Web || engine === PlayerEngine.EmbeddedMpv) {
+      this.memory.SetFocus.next(this.id);
+      this.memory.NowPlaying.next(this.channel!);
+      this.memory.PlayerState.next(PlayerState.Expanded);
+      invoke("add_last_watched", { id: this.channel?.id }).catch(console.error);
+      return;
     }
+
+    // External MPV: standard playback
     this.starting = true;
     this.memory.SetFocus.next(this.id);
+    this.memory.NowPlaying.next(this.channel!);
     try {
       await invoke("play", { channel: this.channel, record: record, recordPath: file });
     } catch (e) {
@@ -135,6 +142,10 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
       this.error.handleError(e);
     });
     this.starting = false;
+    // Only clear NowPlaying if this channel is still the one playing
+    if (this.memory.NowPlaying.value?.id === this.channel?.id) {
+      this.memory.NowPlaying.next(null);
+    }
   }
 
   onRightClick(event: MouseEvent) {

--- a/src/app/inline-player/inline-player.component.css
+++ b/src/app/inline-player/inline-player.component.css
@@ -1,0 +1,654 @@
+/* ═══════════════════════════════════════════════════════
+   Inline Video Player — Three-State Layout
+   States: closed / mini / expanded
+   ═══════════════════════════════════════════════════════ */
+
+/* ── Shared transition ─────────────────────────────── */
+
+.player-container {
+  position: fixed;
+  background: #000;
+  overflow: hidden;
+  transition:
+    width 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    height 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    bottom 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    right 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    top 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    left 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-radius 350ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 350ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.player-container.dragging {
+  transition: none;
+}
+
+/* ── State: Closed ─────────────────────────────────── */
+
+.player-container.state-closed {
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+  bottom: 0;
+  right: 0;
+  z-index: -1;
+}
+
+/* ── State: Expanded ───────────────────────────────── */
+
+.player-container.state-expanded {
+  inset: 0;
+  z-index: 890;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* ── State: Mini ───────────────────────────────────── */
+
+.player-container.state-mini {
+  bottom: 72px;
+  right: 16px;
+  width: 320px;
+  height: 180px;
+  z-index: 850;
+  border-radius: 12px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.5),
+    0 2px 8px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  top: auto;
+  left: auto;
+}
+
+/* ── Video wrapper ─────────────────────────────────── */
+
+.player-video-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.player-video-wrapper video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.state-mini .player-video-wrapper video {
+  object-fit: cover;
+}
+
+/* ── Drag Handle (expanded mode) ───────────────────── */
+
+.drag-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.drag-indicator {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.4);
+  transition: background 150ms ease, width 150ms ease;
+}
+
+.drag-handle:hover .drag-indicator {
+  background: rgba(255, 255, 255, 0.7);
+  width: 52px;
+}
+
+/* ── Loading Spinner ─────────────────────────────── */
+
+.player-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 5;
+}
+
+.player-spinner {
+  width: 48px;
+  height: 48px;
+  border: 3px solid rgba(255, 255, 255, 0.15);
+  border-top-color: var(--ftv-accent);
+  border-radius: 50%;
+  animation: playerSpin 0.8s linear infinite;
+}
+
+.state-mini .player-spinner {
+  width: 28px;
+  height: 28px;
+  border-width: 2px;
+}
+
+@keyframes playerSpin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Frost Backdrop Layer ──────────────────────────── */
+
+.frost-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 400ms ease;
+}
+
+.frost-layer.frost-active {
+  opacity: 1;
+}
+
+.frost-layer.frost-revealing {
+  opacity: 0;
+}
+
+.frost-gradient-bg {
+  position: absolute;
+  inset: -40%;
+  opacity: 1;
+  transition: opacity 500ms ease;
+  background:
+    radial-gradient(ellipse 50% 60% at 20% 30%, rgba(10,132,255,0.6), transparent),
+    radial-gradient(ellipse 40% 50% at 75% 60%, rgba(191,90,242,0.5), transparent),
+    radial-gradient(ellipse 55% 45% at 50% 80%, rgba(48,209,88,0.35), transparent),
+    radial-gradient(ellipse 45% 55% at 60% 20%, rgba(10,132,255,0.4), transparent),
+    radial-gradient(ellipse 60% 50% at 30% 70%, rgba(191,90,242,0.3), transparent);
+  filter: blur(60px) brightness(0.7);
+  animation: frostBlobDrift 8s ease-in-out infinite alternate;
+}
+
+.frost-frame .frost-gradient-bg {
+  opacity: 0;
+}
+
+.frost-frame-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: blur(35px) brightness(1.1);
+  opacity: 0;
+  transition: opacity 500ms ease;
+  transform: scale(1.1);
+}
+
+.frost-frame .frost-frame-bg {
+  opacity: 1;
+}
+
+@keyframes frostBlobDrift {
+  0%   { transform: translate(0%, 0%) rotate(0deg) scale(1); }
+  25%  { transform: translate(5%, -3%) rotate(3deg) scale(1.05); }
+  50%  { transform: translate(-3%, 5%) rotate(-2deg) scale(0.97); }
+  75%  { transform: translate(4%, 2%) rotate(4deg) scale(1.03); }
+  100% { transform: translate(-2%, -4%) rotate(-3deg) scale(1); }
+}
+
+.frost-active ~ .player-loading {
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.state-mini .frost-frame-bg {
+  transform: scale(1.15);
+  border-radius: 12px;
+}
+
+.state-mini .frost-gradient-bg {
+  inset: -60%;
+}
+
+/* ── Controls Overlay (expanded mode only) ─────────── */
+
+.player-controls-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  z-index: 10;
+  opacity: 1;
+  transition: opacity 300ms ease;
+  cursor: default;
+}
+
+.player-controls-overlay:not(.visible) {
+  opacity: 0;
+  cursor: none;
+}
+
+.controls-hidden .player-video-wrapper {
+  cursor: none;
+}
+
+/* ── Top Bar ─────────────────────────────────────── */
+
+.player-top-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 24px 40px;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.player-top-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.player-channel-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.player-source-name {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.player-top-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.player-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--ftv-live);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.player-live-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #fff;
+  animation: liveDot 1.5s ease-in-out infinite;
+}
+
+@keyframes liveDot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.player-rec-badge {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--ftv-danger);
+  letter-spacing: 0.05em;
+}
+
+.player-rec-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ftv-danger);
+  animation: recPulse 1s infinite;
+}
+
+@keyframes recPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* ── Bottom Bar ──────────────────────────────────── */
+
+.player-bottom-bar {
+  display: flex;
+  flex-direction: column;
+  padding: 40px 24px 20px;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+/* ── Seek Bar ────────────────────────────────────── */
+
+.player-seek-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.player-time {
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-variant-numeric: tabular-nums;
+  min-width: 40px;
+  text-align: center;
+  user-select: none;
+}
+
+.player-seek-wrapper {
+  flex: 1;
+  position: relative;
+  height: 20px;
+  display: flex;
+  align-items: center;
+}
+
+.player-seek {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+  background: linear-gradient(
+    to right,
+    var(--ftv-accent) var(--seek-percent, 0%),
+    rgba(255, 255, 255, 0.2) var(--seek-percent, 0%)
+  );
+  transition: height 100ms ease;
+}
+
+.player-seek:hover {
+  height: 6px;
+}
+
+.player-seek::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.player-seek:hover::-webkit-slider-thumb {
+  opacity: 1;
+}
+
+.player-seek::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  border: none;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.player-seek:hover::-moz-range-thumb {
+  opacity: 1;
+}
+
+/* ── Controls Row ────────────────────────────────── */
+
+.player-controls-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.player-spacer {
+  flex: 1;
+}
+
+/* ── Buttons ─────────────────────────────────────── */
+
+.player-btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 150ms ease, transform 100ms ease;
+  flex-shrink: 0;
+}
+
+.player-btn svg {
+  width: 22px;
+  height: 22px;
+}
+
+.player-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.player-btn:active {
+  transform: scale(0.92);
+}
+
+.player-close-btn:hover {
+  background: rgba(255, 69, 58, 0.25);
+  color: var(--ftv-danger);
+}
+
+/* ── Volume ──────────────────────────────────────── */
+
+.player-volume-group {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.player-volume-btn {
+  width: 36px;
+  height: 36px;
+}
+
+.player-volume-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+.player-volume-slider-wrapper {
+  width: 0;
+  overflow: hidden;
+  transition: width 200ms ease;
+}
+
+.player-volume-group:hover .player-volume-slider-wrapper {
+  width: 90px;
+}
+
+.player-volume {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 80px;
+  height: 4px;
+  margin: 0 6px;
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+  background: linear-gradient(
+    to right,
+    #fff var(--volume-percent, 100%),
+    rgba(255, 255, 255, 0.2) var(--volume-percent, 100%)
+  );
+}
+
+.player-volume::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.player-volume::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  border: none;
+}
+
+/* ── Mini-player overlay ───────────────────────────── */
+
+.mini-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 8px 10px;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0) 50%
+  );
+  opacity: 0;
+  transition: opacity 200ms ease;
+  border-radius: 12px;
+  z-index: 10;
+}
+
+.state-mini:hover .mini-overlay {
+  opacity: 1;
+}
+
+.mini-channel-name {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+.mini-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mini-btn {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 150ms ease, transform 100ms ease;
+  flex-shrink: 0;
+}
+
+.mini-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mini-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.mini-btn:active {
+  transform: scale(0.9);
+}
+
+.mini-close-btn:hover {
+  background: rgba(255, 69, 58, 0.4);
+  color: var(--ftv-danger);
+}
+
+/* ── Fullscreen adjustments ──────────────────────── */
+
+:host-context(:fullscreen) .player-container {
+  height: 100vh;
+}
+
+/* ── Responsive ──────────────────────────────────── */
+
+@media screen and (max-width: 600px) {
+  .player-top-bar {
+    padding: 12px 16px 30px;
+  }
+
+  .player-bottom-bar {
+    padding: 30px 16px 12px;
+  }
+
+  .player-channel-name {
+    font-size: 0.95rem;
+  }
+
+  .player-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .player-btn svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .player-container.state-mini {
+    width: 240px;
+    height: 135px;
+    bottom: 68px;
+    right: 8px;
+  }
+}

--- a/src/app/inline-player/inline-player.component.html
+++ b/src/app/inline-player/inline-player.component.html
@@ -1,0 +1,174 @@
+<div
+  class="player-container"
+  [class.state-expanded]="playerState === PlayerState.Expanded"
+  [class.state-mini]="playerState === PlayerState.Mini"
+  [class.state-closed]="!channel || playerState === PlayerState.Closed"
+  [class.controls-hidden]="!controlsVisible && playerState === PlayerState.Expanded"
+  [class.dragging]="isDragging"
+  (mousemove)="onMouseMove()"
+>
+  <!-- Drag handle (expanded mode) -->
+  <div
+    class="drag-handle"
+    *ngIf="playerState === PlayerState.Expanded"
+    (mousedown)="onDragStart($event)"
+    (touchstart)="onDragStart($event)"
+  >
+    <div class="drag-indicator"></div>
+  </div>
+
+  <div class="player-video-wrapper" (click)="onVideoClick($event)">
+    <video #videoElement playsinline></video>
+
+    <!-- Frost backdrop layer -->
+    <div
+      class="frost-layer"
+      [class.frost-active]="frostPhase !== 'none'"
+      [class.frost-gradient]="frostPhase === 'gradient'"
+      [class.frost-frame]="frostPhase === 'frosted-frame'"
+      [class.frost-revealing]="frostPhase === 'revealing'"
+    >
+      <div class="frost-gradient-bg"></div>
+      <div
+        class="frost-frame-bg"
+        [style.backgroundImage]="frostFrameUrl ? 'url(' + frostFrameUrl + ')' : 'none'"
+      ></div>
+    </div>
+
+    <!-- Loading spinner -->
+    <div class="player-loading" *ngIf="loading && playerState !== PlayerState.Closed">
+      <div class="player-spinner"></div>
+    </div>
+
+    <!-- Controls overlay (expanded mode only) -->
+    <div
+      class="player-controls-overlay"
+      *ngIf="playerState === PlayerState.Expanded"
+      [class.visible]="controlsVisible"
+    >
+      <!-- Top gradient + info -->
+      <div class="player-top-bar">
+        <div class="player-top-info">
+          <span class="player-channel-name">{{ channel?.name }}</span>
+          <span class="player-source-name">{{ getSourceName() }}</span>
+        </div>
+        <div class="player-top-actions">
+          <span class="player-live-badge" *ngIf="isLive">LIVE</span>
+          <span class="player-rec-badge" *ngIf="isCurrentChannelRecording()">
+            <span class="player-rec-dot"></span>
+            REC
+          </span>
+          <button class="player-btn player-close-btn" (click)="close()" title="Stop & Close">
+            <svg viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Bottom controls -->
+      <div class="player-bottom-bar">
+        <!-- Seek bar (VOD only) -->
+        <div class="player-seek-row" *ngIf="!isLive">
+          <span class="player-time">{{ formatTime(currentTime) }}</span>
+          <div class="player-seek-wrapper">
+            <input
+              type="range"
+              class="player-seek"
+              min="0"
+              [max]="duration"
+              [value]="currentTime"
+              step="0.1"
+              (input)="onSeek($event)"
+              [style.--seek-percent]="seekPercent + '%'"
+            />
+          </div>
+          <span class="player-time">{{ formatTime(duration) }}</span>
+        </div>
+
+        <div class="player-controls-row">
+          <!-- Play/Pause -->
+          <button class="player-btn" (click)="togglePlay()" title="Play/Pause">
+            <svg *ngIf="!isPlaying" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M8,5.14V19.14L19,12.14L8,5.14Z" />
+            </svg>
+            <svg *ngIf="isPlaying" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M14,19H18V5H14M6,19H10V5H6V19Z" />
+            </svg>
+          </button>
+
+          <!-- Volume -->
+          <div class="player-volume-group">
+            <button class="player-btn player-volume-btn" (click)="toggleMute()" title="Mute">
+              <svg *ngIf="!isMuted && volume > 50" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" />
+              </svg>
+              <svg *ngIf="!isMuted && volume > 0 && volume <= 50" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M5,9V15H9L14,20V4L9,9M18.5,12C18.5,10.23 17.5,8.71 16,7.97V16C17.5,15.29 18.5,13.76 18.5,12Z" />
+              </svg>
+              <svg *ngIf="isMuted || volume === 0" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.45 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" />
+              </svg>
+            </button>
+            <div class="player-volume-slider-wrapper">
+              <input
+                type="range"
+                class="player-volume"
+                min="0"
+                max="100"
+                [value]="volumePercent"
+                (input)="onVolumeChange($event)"
+                [style.--volume-percent]="volumePercent + '%'"
+              />
+            </div>
+          </div>
+
+          <!-- Spacer -->
+          <div class="player-spacer"></div>
+
+          <!-- Minimize to mini-player -->
+          <button class="player-btn" (click)="minimize()" title="Mini Player">
+            <svg viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19.5,3.09L15,7.59V4H13V11H20V9H16.41L20.91,4.5L19.5,3.09M4,13V15H7.59L3.09,19.5L4.5,20.91L9,16.41V20H11V13H4Z" />
+            </svg>
+          </button>
+
+          <!-- Fullscreen -->
+          <button class="player-btn" (click)="toggleFullscreen()" title="Fullscreen">
+            <svg *ngIf="!isFullscreen" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
+            </svg>
+            <svg *ngIf="isFullscreen" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M14,14H19V16H16V19H14V14M5,14H10V19H8V16H5V14M8,5H10V10H5V8H8V5M19,8V10H14V5H16V8H19Z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mini-player overlay -->
+  <div class="mini-overlay" *ngIf="playerState === PlayerState.Mini">
+    <span class="mini-channel-name">{{ channel?.name }}</span>
+    <div class="mini-controls">
+      <button class="mini-btn" (click)="togglePlay(); $event.stopPropagation()" title="Play/Pause">
+        <svg *ngIf="!isPlaying" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M8,5.14V19.14L19,12.14L8,5.14Z" />
+        </svg>
+        <svg *ngIf="isPlaying" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M14,19H18V5H14M6,19H10V5H6V19Z" />
+        </svg>
+      </button>
+      <button class="mini-btn" (click)="expand(); $event.stopPropagation()" title="Expand">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
+        </svg>
+      </button>
+      <button class="mini-btn mini-close-btn" (click)="close(); $event.stopPropagation()" title="Close">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/inline-player/inline-player.component.ts
+++ b/src/app/inline-player/inline-player.component.ts
@@ -1,0 +1,560 @@
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  HostListener,
+  NgZone,
+} from "@angular/core";
+import { Subscription } from "rxjs";
+import { invoke } from "@tauri-apps/api/core";
+import Hls from "hls.js";
+import { MemoryService } from "../memory.service";
+import { Channel } from "../models/channel";
+import { MediaType } from "../models/mediaType";
+import { PlayerEngine } from "../models/playerEngine";
+import { PlayerState } from "../models/playerState";
+import { ErrorService } from "../error.service";
+import { Settings } from "../models/settings";
+import { RecordingService } from "../recording.service";
+
+interface StreamInfo {
+  url: string;
+  has_custom_headers: boolean;
+  is_hls: boolean;
+}
+
+@Component({
+  selector: "app-inline-player",
+  templateUrl: "./inline-player.component.html",
+  styleUrl: "./inline-player.component.css",
+})
+export class InlinePlayerComponent implements OnInit, OnDestroy {
+  @ViewChild("videoElement", { static: true }) videoRef!: ElementRef<HTMLVideoElement>;
+
+  channel: Channel | null = null;
+  playerState: PlayerState = PlayerState.Closed;
+  isPlaying = false;
+  isLive = true;
+  isMuted = false;
+  volume = 100;
+  currentTime = 0;
+  duration = 0;
+  controlsVisible = true;
+  isFullscreen = false;
+  loading = true;
+  isDragging = false;
+
+  // Frost backdrop state
+  frostPhase: 'none' | 'gradient' | 'frosted-frame' | 'revealing' = 'none';
+  frostFrameUrl: string | null = null;
+  private frostCanvas: HTMLCanvasElement | null = null;
+  private frostCtx: CanvasRenderingContext2D | null = null;
+  private frostRevealTimer: any = null;
+  private frameCheckInterval: any = null;
+
+  private hls: Hls | null = null;
+  private subscriptions: Subscription[] = [];
+  private controlsTimer: any = null;
+  private usingProxy = false;
+  private dragStartY = 0;
+  private dragThreshold = 150;
+  private lastMouseMove = 0;
+
+  // Stored listener refs for proper cleanup
+  private onTimeUpdate: (() => void) | null = null;
+  private onWaiting: (() => void) | null = null;
+  private onPlaying: (() => void) | null = null;
+  private onLoadedMetadata: (() => void) | null = null;
+
+  // Expose enum to template
+  PlayerState = PlayerState;
+
+  constructor(
+    public memory: MemoryService,
+    private error: ErrorService,
+    private zone: NgZone,
+    public recording: RecordingService,
+  ) {}
+
+  isCurrentChannelRecording(): boolean {
+    return !!this.channel?.id && this.recording.isRecording(this.channel.id);
+  }
+
+  ngOnInit() {
+    this.subscriptions.push(
+      this.memory.NowPlaying.subscribe((ch) => {
+        if (ch && this.memory.PlayerEngine.value === PlayerEngine.Web) {
+          const isNewChannel = !this.channel || this.channel.id !== ch.id;
+          this.channel = ch;
+          this.isLive = ch.media_type === MediaType.livestream;
+          this.memory.PlayerState.next(PlayerState.Expanded);
+          if (isNewChannel) {
+            this.loadSettings().then(() => this.startPlayback());
+          }
+        } else if (!ch) {
+          this.stopPlayback();
+        }
+      }),
+    );
+
+    this.subscriptions.push(
+      this.memory.PlayerState.subscribe((state) => {
+        this.playerState = state;
+      }),
+    );
+  }
+
+  ngOnDestroy() {
+    this.stopPlayback();
+    this.subscriptions.forEach((s) => s.unsubscribe());
+    this.clearControlsTimer();
+    this.stopFrameDetection();
+    this.frostCanvas = null;
+    this.frostCtx = null;
+  }
+
+  @HostListener("document:keydown.escape")
+  onEscapeKey() {
+    if (this.playerState === PlayerState.Expanded) {
+      this.minimize();
+    }
+  }
+
+  private async loadSettings() {
+    try {
+      const settings = (await invoke("get_settings")) as Settings;
+      this.volume = settings.volume ?? 100;
+    } catch (_) {
+      this.volume = 100;
+    }
+  }
+
+  private async startPlayback() {
+    if (!this.videoRef?.nativeElement || !this.channel) return;
+
+    const video = this.videoRef.nativeElement;
+    this.loading = true;
+    this.showFrostGradient();
+    this.startFrameDetection();
+
+    try {
+      const info: StreamInfo = await invoke("get_stream_info", { channel: this.channel });
+
+      let playUrl = info.url;
+
+      if (!info.is_hls || info.has_custom_headers) {
+        playUrl = await invoke("start_local_stream", { channel: this.channel });
+        this.usingProxy = true;
+        this.memory.LocalProxyRunning = true;
+        // Wait for ffmpeg to produce at least one segment
+        await this.waitForManifest(playUrl);
+      }
+
+      this.attachHls(video, playUrl);
+    } catch (e) {
+      this.error.handleError(e, "Failed to start inline playback");
+      this.stopPlayback();
+    }
+  }
+
+  private async waitForManifest(url: string, timeoutMs = 15000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const resp = await fetch(url);
+        if (resp.ok) {
+          const text = await resp.text();
+          if (text.includes("#EXTINF")) return;
+        }
+      } catch (_) {}
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  private attachHls(video: HTMLVideoElement, url: string) {
+    this.destroyHls();
+
+    if (Hls.isSupported()) {
+      this.hls = new Hls({
+        enableWorker: true,
+        lowLatencyMode: this.isLive,
+        maxBufferLength: this.isLive ? 30 : 60,
+        maxMaxBufferLength: this.isLive ? 60 : 600,
+        backBufferLength: this.isLive ? 30 : 60,
+        liveSyncDurationCount: 3,
+        liveMaxLatencyDurationCount: 10,
+        fragLoadingMaxRetry: 6,
+        fragLoadingRetryDelay: 1000,
+        manifestLoadingMaxRetry: 4,
+        manifestLoadingRetryDelay: 1000,
+        levelLoadingMaxRetry: 4,
+        levelLoadingRetryDelay: 1000,
+        startFragPrefetch: true,
+      });
+      this.hls.loadSource(url);
+      this.hls.attachMedia(video);
+      this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        this.zone.run(() => {
+          this.loading = false;
+          this.hideFrost();
+        });
+        video.volume = this.volume / 100;
+        video.play().catch(() => {});
+        this.isPlaying = true;
+      });
+      this.hls.on(Hls.Events.ERROR, (_event: any, data: any) => {
+        if (data.fatal) {
+          switch (data.type) {
+            case Hls.ErrorTypes.NETWORK_ERROR:
+              this.hls?.startLoad();
+              break;
+            case Hls.ErrorTypes.MEDIA_ERROR:
+              this.hls?.recoverMediaError();
+              break;
+            default:
+              this.zone.run(() => {
+                this.error.handleError(data.details, "Playback error");
+                this.stopPlayback();
+              });
+              break;
+          }
+        }
+      });
+    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = url;
+      this.onLoadedMetadata = () => {
+        this.loading = false;
+        this.hideFrost();
+        video.volume = this.volume / 100;
+        video.play().catch(() => {});
+        this.isPlaying = true;
+      };
+      video.addEventListener("loadedmetadata", this.onLoadedMetadata);
+    }
+
+    this.removeVideoListeners();
+
+    this.onTimeUpdate = () => {
+      this.zone.run(() => {
+        this.currentTime = video.currentTime;
+        this.duration = video.duration || 0;
+      });
+    };
+    video.addEventListener("timeupdate", this.onTimeUpdate);
+
+    this.onWaiting = () => {
+      this.zone.run(() => {
+        this.loading = true;
+        this.showFrostFrame();
+      });
+    };
+    video.addEventListener("waiting", this.onWaiting);
+
+    this.onPlaying = () => {
+      this.zone.run(() => {
+        this.loading = false;
+        this.hideFrost();
+      });
+    };
+    video.addEventListener("playing", this.onPlaying);
+
+    this.startControlsTimer();
+  }
+
+  private removeVideoListeners() {
+    const video = this.videoRef?.nativeElement;
+    if (!video) return;
+    if (this.onTimeUpdate) { video.removeEventListener("timeupdate", this.onTimeUpdate); this.onTimeUpdate = null; }
+    if (this.onWaiting) { video.removeEventListener("waiting", this.onWaiting); this.onWaiting = null; }
+    if (this.onPlaying) { video.removeEventListener("playing", this.onPlaying); this.onPlaying = null; }
+    if (this.onLoadedMetadata) { video.removeEventListener("loadedmetadata", this.onLoadedMetadata); this.onLoadedMetadata = null; }
+  }
+
+  private destroyHls() {
+    this.removeVideoListeners();
+    if (this.hls) {
+      this.hls.destroy();
+      this.hls = null;
+    }
+  }
+
+  async stopPlayback() {
+    this.destroyHls();
+    if (this.usingProxy) {
+      try { await invoke("stop_local_stream"); } catch (_) {}
+      this.usingProxy = false;
+      this.memory.LocalProxyRunning = false;
+    }
+    this.channel = null;
+    this.isPlaying = false;
+    this.loading = true;
+    this.frostPhase = 'none';
+    this.frostFrameUrl = null;
+    this.stopFrameDetection();
+    if (this.frostRevealTimer) {
+      clearTimeout(this.frostRevealTimer);
+      this.frostRevealTimer = null;
+    }
+    this.memory.PlayerState.next(PlayerState.Closed);
+    this.clearControlsTimer();
+  }
+
+  close() {
+    this.memory.NowPlaying.next(null);
+  }
+
+  togglePlay() {
+    const video = this.videoRef?.nativeElement;
+    if (!video) return;
+    if (video.paused) {
+      video.play().catch(() => {});
+      this.isPlaying = true;
+    } else {
+      video.pause();
+      this.isPlaying = false;
+    }
+  }
+
+  onVolumeChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.volume = parseInt(target.value);
+    const video = this.videoRef?.nativeElement;
+    if (video) {
+      video.volume = this.volume / 100;
+      this.isMuted = this.volume === 0;
+    }
+  }
+
+  toggleMute() {
+    const video = this.videoRef?.nativeElement;
+    if (!video) return;
+    if (this.isMuted) {
+      video.volume = this.volume / 100;
+      this.isMuted = false;
+    } else {
+      video.volume = 0;
+      this.isMuted = true;
+    }
+  }
+
+  onSeek(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const time = parseFloat(target.value);
+    const video = this.videoRef?.nativeElement;
+    if (video) {
+      video.currentTime = time;
+    }
+  }
+
+  minimize() {
+    this.memory.PlayerState.next(PlayerState.Mini);
+  }
+
+  expand() {
+    this.memory.PlayerState.next(PlayerState.Expanded);
+  }
+
+  onVideoClick(event: Event) {
+    if (this.playerState === PlayerState.Mini) {
+      event.stopPropagation();
+      this.expand();
+    }
+  }
+
+  toggleFullscreen() {
+    const container = this.videoRef?.nativeElement?.closest('.player-container') as HTMLElement;
+    if (!container) return;
+    if (!document.fullscreenElement) {
+      container.requestFullscreen().catch(() => {});
+      this.isFullscreen = true;
+    } else {
+      document.exitFullscreen().catch(() => {});
+      this.isFullscreen = false;
+    }
+  }
+
+  @HostListener("document:fullscreenchange")
+  onFullscreenChange() {
+    this.isFullscreen = !!document.fullscreenElement;
+  }
+
+  onMouseMove() {
+    if (this.playerState !== PlayerState.Expanded) return;
+    const now = Date.now();
+    if (now - this.lastMouseMove < 200) return;
+    this.lastMouseMove = now;
+    this.controlsVisible = true;
+    this.startControlsTimer();
+  }
+
+  onDragStart(event: MouseEvent | TouchEvent) {
+    if (this.playerState !== PlayerState.Expanded) return;
+    event.preventDefault();
+    this.isDragging = true;
+    const clientY = event instanceof MouseEvent ? event.clientY : event.touches[0].clientY;
+    this.dragStartY = clientY;
+
+    const container = this.videoRef?.nativeElement?.closest('.player-container') as HTMLElement;
+
+    const onMove = (e: MouseEvent | TouchEvent) => {
+      const currentY = e instanceof MouseEvent ? e.clientY : e.touches[0].clientY;
+      const delta = currentY - this.dragStartY;
+      if (delta > 0 && container) {
+        const clamped = Math.min(delta, 300);
+        container.style.transform = `translateY(${clamped}px) scale(${Math.max(0.85, 1 - clamped / 1000)})`;
+        container.style.opacity = `${Math.max(0.4, 1 - delta / 500)}`;
+      }
+    };
+
+    const onEnd = (e: MouseEvent | TouchEvent) => {
+      const endY = e instanceof MouseEvent ? e.clientY : (e as TouchEvent).changedTouches[0].clientY;
+      const delta = endY - this.dragStartY;
+
+      if (container) {
+        container.style.transform = '';
+        container.style.opacity = '';
+      }
+
+      this.zone.run(() => {
+        if (delta > this.dragThreshold) {
+          this.minimize();
+        }
+        this.isDragging = false;
+      });
+
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onEnd);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onEnd);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onEnd);
+    document.addEventListener('touchmove', onMove);
+    document.addEventListener('touchend', onEnd);
+  }
+
+  private startControlsTimer() {
+    this.clearControlsTimer();
+    this.controlsTimer = setTimeout(() => {
+      if (this.isPlaying && this.playerState === PlayerState.Expanded) {
+        this.zone.run(() => {
+          this.controlsVisible = false;
+        });
+      }
+    }, 3000);
+  }
+
+  private clearControlsTimer() {
+    if (this.controlsTimer) {
+      clearTimeout(this.controlsTimer);
+      this.controlsTimer = null;
+    }
+  }
+
+  // ── Frost backdrop methods ──────────────────────────
+
+  private initFrostCanvas() {
+    if (this.frostCanvas) return;
+    this.frostCanvas = document.createElement('canvas');
+    this.frostCtx = this.frostCanvas.getContext('2d');
+  }
+
+  private captureVideoFrame(): string | null {
+    const video = this.videoRef?.nativeElement;
+    if (!video || video.videoWidth === 0) return null;
+    this.initFrostCanvas();
+    if (!this.frostCanvas || !this.frostCtx) return null;
+    const w = Math.floor(video.videoWidth * 0.25);
+    const h = Math.floor(video.videoHeight * 0.25);
+    this.frostCanvas.width = w;
+    this.frostCanvas.height = h;
+    try {
+      this.frostCtx.drawImage(video, 0, 0, w, h);
+      return this.frostCanvas.toDataURL('image/jpeg', 0.5);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  private showFrostGradient() {
+    this.frostFrameUrl = null;
+    this.frostPhase = 'gradient';
+  }
+
+  private startFrameDetection() {
+    this.stopFrameDetection();
+    this.frameCheckInterval = setInterval(() => {
+      const video = this.videoRef?.nativeElement;
+      if (video && video.videoWidth > 0) {
+        const frame = this.captureVideoFrame();
+        if (frame) {
+          this.zone.run(() => {
+            this.frostFrameUrl = frame;
+            this.frostPhase = 'frosted-frame';
+          });
+        }
+        this.stopFrameDetection();
+      }
+    }, 100);
+  }
+
+  private stopFrameDetection() {
+    if (this.frameCheckInterval) {
+      clearInterval(this.frameCheckInterval);
+      this.frameCheckInterval = null;
+    }
+  }
+
+  private showFrostFrame() {
+    const frame = this.captureVideoFrame();
+    if (frame) {
+      this.frostFrameUrl = frame;
+      this.frostPhase = 'frosted-frame';
+    } else {
+      this.showFrostGradient();
+    }
+  }
+
+  private hideFrost() {
+    if (this.frostPhase === 'none') return;
+    this.stopFrameDetection();
+    this.frostPhase = 'revealing';
+    if (this.frostRevealTimer) {
+      clearTimeout(this.frostRevealTimer);
+    }
+    this.frostRevealTimer = setTimeout(() => {
+      this.zone.run(() => {
+        this.frostPhase = 'none';
+        this.frostRevealTimer = null;
+      });
+    }, 420);
+  }
+
+  getSourceName(): string {
+    if (!this.channel?.source_id) return "";
+    return this.memory.Sources.get(this.channel.source_id)?.name || "";
+  }
+
+  formatTime(seconds: number): string {
+    if (!isFinite(seconds) || seconds < 0) return "0:00";
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+    }
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  }
+
+  get seekPercent(): number {
+    if (!this.duration || !isFinite(this.duration)) return 0;
+    return (this.currentTime / this.duration) * 100;
+  }
+
+  get volumePercent(): number {
+    return this.isMuted ? 0 : this.volume;
+  }
+}

--- a/src/app/memory.service.ts
+++ b/src/app/memory.service.ts
@@ -9,6 +9,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { SortType } from "./models/sortType";
 import { LAST_SEEN_VERSION } from "./models/localStorage";
 import { SetNodeDTO } from "./models/setNodeDTO";
+import { Channel } from "./models/channel";
+import { PlayerEngine } from "./models/playerEngine";
+import { PlayerState } from "./models/playerState";
+import { Settings } from "./models/settings";
 
 @Injectable({
   providedIn: "root",
@@ -19,6 +23,11 @@ export class MemoryService {
     private error: ErrorService,
   ) {
     invoke("is_container").then((val) => (this.IsContainer = val as boolean));
+    invoke("get_settings").then((s) => {
+      const settings = s as Settings;
+      this.PlayerEngine.next(settings.player_engine ?? PlayerEngine.Web);
+      this.AlwaysAskSave = settings.always_ask_save;
+    });
   }
   public SetNode: Subject<SetNodeDTO> = new Subject();
   public SetFocus: Subject<number> = new Subject();
@@ -44,6 +53,12 @@ export class MemoryService {
   public trayEnabled?: boolean;
   public IsContainer?: boolean;
   public AlwaysAskSave?: boolean;
+
+  // Now playing state
+  public NowPlaying: BehaviorSubject<Channel | null> = new BehaviorSubject<Channel | null>(null);
+  public PlayerState: BehaviorSubject<PlayerState> = new BehaviorSubject<PlayerState>(PlayerState.Closed);
+  public PlayerEngine: BehaviorSubject<number> = new BehaviorSubject<number>(0);
+  public LocalProxyRunning: boolean = false;
 
   async tryIPC<T>(
     successMessage: string,

--- a/src/app/models/playerEngine.ts
+++ b/src/app/models/playerEngine.ts
@@ -1,0 +1,5 @@
+export enum PlayerEngine {
+  Web = 0,
+  EmbeddedMpv = 1,
+  ExternalMpv = 2,
+}

--- a/src/app/models/playerState.ts
+++ b/src/app/models/playerState.ts
@@ -1,0 +1,5 @@
+export enum PlayerState {
+  Closed = 'closed',
+  Mini = 'mini',
+  Expanded = 'expanded',
+}

--- a/src/app/models/settings.ts
+++ b/src/app/models/settings.ts
@@ -12,4 +12,5 @@ export class Settings {
   enable_hwdec?: boolean;
   always_ask_save?: boolean;
   enable_gpu?: boolean;
+  player_engine?: number;
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -88,6 +88,23 @@
 
   <div class="row mt-3 align-items-center">
     <div class="col-4">
+      <span [ngbTooltip]="'Choose how video is played'">Player engine</span>
+    </div>
+    <div class="col">
+      <select
+        (ngModelChange)="updateSettings(); memory.PlayerEngine.next(settings.player_engine!)"
+        [(ngModel)]="settings.player_engine"
+        class="form-control"
+      >
+        <option [ngValue]="playerEngineEnum.Web">Web Player (Inline)</option>
+        <option [ngValue]="playerEngineEnum.EmbeddedMpv">Embedded MPV (Inline)</option>
+        <option [ngValue]="playerEngineEnum.ExternalMpv">External MPV (Popout)</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="row mt-3 align-items-center">
+    <div class="col-4">
       <span>Volume on start</span>
     </div>
     <div class="col d-inline-flex">

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -10,6 +10,7 @@ import { ViewMode } from "../models/viewMode";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { ConfirmDeleteModalComponent } from "../confirm-delete-modal/confirm-delete-modal.component";
 import { SORT_TYPES, SortType, getSortTypeText } from "../models/sortType";
+import { PlayerEngine } from "../models/playerEngine";
 
 @Component({
   selector: "app-settings",
@@ -30,10 +31,11 @@ export class SettingsComponent {
     always_ask_save: false,
     enable_gpu: false,
   };
+  playerEngineEnum = PlayerEngine;
   viewModeEnum = ViewMode;
   sources: Source[] = [];
   sortTypes = SORT_TYPES;
-  @ViewChild("mpvParams") mpvParams!: ElementRef;
+  @ViewChild("mpvParams") mpvParams?: ElementRef;
 
   constructor(
     private router: Router,
@@ -89,6 +91,8 @@ export class SettingsComponent {
       if (this.settings.enable_hwdec == undefined) this.settings.enable_hwdec = true;
       if (this.settings.always_ask_save == undefined) this.settings.always_ask_save = false;
       if (this.settings.enable_gpu == undefined) this.settings.enable_gpu = false;
+      if (this.settings.player_engine == undefined) this.settings.player_engine = PlayerEngine.Web;
+      this.memory.PlayerEngine.next(this.settings.player_engine);
     });
   }
 
@@ -103,19 +107,22 @@ export class SettingsComponent {
   }
 
   ngAfterViewInit(): void {
-    this.subscriptions.push(
-      fromEvent(this.mpvParams.nativeElement, "keyup")
-        .pipe(
-          map((event: any) => {
-            return event.target.value;
+    const mpvEl = this.mpvParams?.nativeElement;
+    if (mpvEl) {
+      this.subscriptions.push(
+        fromEvent(mpvEl, "keyup")
+          .pipe(
+            map((event: any) => {
+              return event.target.value;
+            }),
+            debounceTime(500),
+            distinctUntilChanged(),
+          )
+          .subscribe(async () => {
+            await this.updateSettings();
           }),
-          debounceTime(500),
-          distinctUntilChanged(),
-        )
-        .subscribe(async () => {
-          await this.updateSettings();
-        }),
-    );
+      );
+    }
     this.subscriptions.push(
       this.memory.RefreshSources.subscribe((_) => {
         this.getSources();


### PR DESCRIPTION
> **Full source available at [FredTV-Next](https://github.com/wowitsjack/FredTV-Next)**, my personal fork with all features integrated.

## Summary
- Adds an inline video player component supporting **Web (hls.js)** and **Embedded MPV** playback engines alongside the existing External MPV
- New `local_player.rs` backend proxies streams via ffmpeg to localhost for the inline player
- Player engine is configurable in Settings (Web Player / Embedded MPV / External MPV)
- Channel clicks now route to the inline player for Web/EmbeddedMpv engines, or to the legacy external MPV for ExternalMpv

## New in this update
- **Fix: proxy manifest caching** - Warp server now serves `stream.m3u8` with `Cache-Control: no-cache` headers, fixing the 6-second buffer starvation bug on proxy-routed streams
- **Direct HLS for redirect streams** - `get_stream_info` resolves 302 redirect chains via HEAD request, enabling direct HLS playback for streams like tvpass.org without the ffmpeg proxy
- **Automatic proxy fallback** - If direct HLS hits a fatal network error (CORS, etc.), player falls back to the ffmpeg proxy automatically
- **HLS.js tuning** - Configurable buffer sizes, lower `liveSyncDurationCount` for proxy streams, `xhrSetup` cache-busting on manifest requests
- **Buffer size setting** - New user-facing buffer size selector in Settings (Low/Medium/High/Maximum)
- **HTTP client module** - Centralized `http.rs` with proxy/UA/timeout support
- **Scheduler module** - EPG and source refresh scheduling
- **Backup module** - Export/import full backups

## Dependencies
> **Stacked on #392** (feat/recording-system) - merge that first, then this PR's diff auto-narrows.

## New files
- `src-tauri/src/local_player.rs` - ffmpeg stream proxy backend with no-cache manifest serving
- `src-tauri/src/http.rs` - centralized HTTP client builder
- `src-tauri/src/backup.rs` - backup export/import
- `src-tauri/src/scheduler.rs` - EPG and source refresh scheduler
- `src/app/inline-player/` - Angular inline player component (ts/html/css)
- `src/app/models/playerEngine.ts` - PlayerEngine enum
- `src/app/models/playerState.ts` - PlayerState enum

## Modified files
- `src-tauri/src/lib.rs` - local_player module, new commands, ExitRequested handler, scheduler init
- `src-tauri/src/types.rs` - StreamInfo (with resolved_url), buffer_size in Settings, AppState
- `src-tauri/src/settings.rs` - player_engine, buffer_size, connection_timeout persistence
- `src-tauri/src/m3u.rs` - uses centralized http client
- `src-tauri/src/restream.rs` - uses centralized http client
- `src-tauri/src/utils.rs` - uses centralized http client
- `src-tauri/src/xtream.rs` - uses centralized http client
- `src/app/channel-tile/channel-tile.component.ts` - click() refactored for engine routing
- `src/app/memory.service.ts` - NowPlaying, PlayerState, PlayerEngine subjects
- `src/app/settings/settings.component.ts` + `.html` - player engine selector, buffer size
- `src/app/models/settings.ts` - buffer_size, enable_gpu, enable_hwdec fields
- `src/app/app.component.ts` - PlayerState subscription

## Test plan
- [ ] Select "Web Player" in Settings, click a livestream -> plays inline via hls.js
- [ ] Proxy streams (Disney Channel via tvpass.org): manifest refreshes, no 6-second stall
- [ ] Redirect streams: resolved via HEAD, direct HLS playback without proxy
- [ ] Direct HLS failure: automatic fallback to proxy, no user-visible error
- [ ] Normal .m3u8 streams: unchanged behavior
- [ ] Streams with custom headers: still routed through proxy
- [ ] Buffer size setting works across Low/Medium/High/Maximum
- [ ] `cargo check` and `npx ng build` both pass