### PR TITLE
feat: backend foundations - HTTP client, recording, scheduler, backup, local player

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "bytes",
  "chrono",
  "directories",
+ "hyper 0.14.32",
  "if-addrs",
  "indexmap 2.12.1",
  "log",
@@ -2995,6 +2996,7 @@ dependencies = [
  "tokio-util",
  "url",
  "warp",
+ "webkit2gtk",
  "which",
  "winsplit",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,11 +42,14 @@ rusqlite_migration = "1.3.1"
 base64 = "0.22.1"
 tauri-plugin-notification = "2.3.3"
 warp = "0.3.7"
+hyper = "0.14"
 if-addrs = "0.13.4"
 tokio-util = "0.7.17"
 indexmap = "2.12.1"
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 shell-words = "1.1.0"
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = "2.0.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 winsplit = "0.1.0"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/linux/custom.desktop
+++ b/src-tauri/linux/custom.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Categories={{categories}}
 Comment={{comment}}
-Exec=env WEBKIT_DISABLE_DMABUF_RENDERER=1 open_tv
+Exec=open_tv
 Icon={{icon}}
 Keywords=open;tv;opentv;
 Name={{name}}

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -1,0 +1,389 @@
+use std::collections::HashMap;
+use std::fs;
+
+use anyhow::{Context, Result, bail};
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::sql;
+use crate::types::{
+    Channel, ChannelHttpHeaders, Group, Season, Source, Settings,
+};
+use crate::settings;
+
+const BACKUP_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+pub struct Backup {
+    pub version: u32,
+    pub created_at: String,
+    pub settings: Settings,
+    pub sources: Vec<Source>,
+    pub groups: Vec<Group>,
+    pub channels: Vec<Channel>,
+    pub channel_http_headers: Vec<ChannelHttpHeaders>,
+    pub seasons: Vec<Season>,
+    pub epg_watchlist: Vec<EpgEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct EpgEntry {
+    pub epg_id: String,
+    pub channel_name: String,
+    pub title: String,
+    pub start_timestamp: i64,
+}
+
+pub fn export_backup(path: String) -> Result<()> {
+    let conn = sql::get_conn()?;
+
+    let app_settings = settings::get_settings()?;
+
+    let sources: Vec<Source> = conn
+        .prepare("SELECT * FROM sources")?
+        .query_map([], |row| {
+            Ok(Source {
+                id: row.get("id")?,
+                name: row.get("name")?,
+                username: row.get("username")?,
+                password: row.get("password")?,
+                url: row.get("url")?,
+                source_type: row.get("source_type")?,
+                url_origin: None,
+                enabled: row.get("enabled")?,
+                use_tvg_id: row.get("use_tvg_id")?,
+                user_agent: row.get("user_agent")?,
+                max_streams: row.get("max_streams")?,
+                stream_user_agent: row.get("stream_user_agent")?,
+                last_updated: row.get("last_updated")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let groups: Vec<Group> = conn
+        .prepare("SELECT * FROM groups")?
+        .query_map([], |row| {
+            Ok(Group {
+                id: row.get("id")?,
+                name: row.get("name")?,
+                image: row.get("image")?,
+                source_id: row.get("source_id")?,
+                hidden: row.get("hidden")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let channels: Vec<Channel> = conn
+        .prepare("SELECT * FROM channels")?
+        .query_map([], |row| {
+            Ok(Channel {
+                id: row.get("id")?,
+                name: row.get("name")?,
+                url: row.get("url")?,
+                group: None,
+                image: row.get("image")?,
+                media_type: row.get("media_type")?,
+                source_id: row.get("source_id")?,
+                series_id: row.get("series_id")?,
+                group_id: row.get("group_id")?,
+                favorite: row.get("favorite")?,
+                stream_id: row.get("stream_id")?,
+                tv_archive: row.get("tv_archive")?,
+                season_id: row.get("season_id")?,
+                episode_num: row.get("episode_num")?,
+                hidden: row.get("hidden")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let headers: Vec<ChannelHttpHeaders> = conn
+        .prepare("SELECT * FROM channel_http_headers")?
+        .query_map([], |row| {
+            Ok(ChannelHttpHeaders {
+                id: row.get("id")?,
+                channel_id: row.get("channel_id")?,
+                referrer: row.get("referrer")?,
+                user_agent: row.get("user_agent")?,
+                http_origin: row.get("http_origin")?,
+                ignore_ssl: row.get("ignore_ssl")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let seasons: Vec<Season> = conn
+        .prepare("SELECT * FROM seasons")?
+        .query_map([], |row| {
+            Ok(Season {
+                id: row.get("id")?,
+                name: row.get("name")?,
+                season_number: row.get("season_number")?,
+                series_id: row.get("series_id")?,
+                source_id: row.get("source_id")?,
+                image: row.get("image")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let epg_watchlist: Vec<EpgEntry> = conn
+        .prepare("SELECT * FROM epg")?
+        .query_map([], |row| {
+            Ok(EpgEntry {
+                epg_id: row.get("epg_id")?,
+                channel_name: row.get("channel_name")?,
+                title: row.get("title")?,
+                start_timestamp: row.get("start_timestamp")?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let backup = Backup {
+        version: BACKUP_VERSION,
+        created_at: chrono::Local::now().to_rfc3339(),
+        settings: app_settings,
+        sources,
+        groups,
+        channels,
+        channel_http_headers: headers,
+        seasons,
+        epg_watchlist,
+    };
+
+    let json = serde_json::to_string_pretty(&backup)?;
+    fs::write(&path, json)?;
+    Ok(())
+}
+
+pub fn import_backup(path: String, mode: String) -> Result<()> {
+    let data = fs::read_to_string(&path)?;
+    let backup: Backup = serde_json::from_str(&data)
+        .context("Invalid backup file format")?;
+
+    if backup.version > BACKUP_VERSION {
+        bail!("Backup version {} is newer than supported version {}", backup.version, BACKUP_VERSION);
+    }
+
+    match mode.as_str() {
+        "replace" => import_replace(backup),
+        "merge" => import_merge(backup),
+        _ => bail!("Unknown import mode: {}", mode),
+    }
+}
+
+fn import_replace(backup: Backup) -> Result<()> {
+    let mut conn = sql::get_conn()?;
+    let tx = conn.transaction()?;
+
+    // Wipe all data tables (order matters for FK constraints)
+    tx.execute_batch(
+        r#"
+        DELETE FROM channel_http_headers;
+        DELETE FROM epg;
+        DELETE FROM seasons;
+        DELETE FROM channels;
+        DELETE FROM groups;
+        DELETE FROM sources;
+        DELETE FROM settings;
+        "#
+    )?;
+
+    // Restore sources (with original IDs so FK refs work)
+    for source in &backup.sources {
+        tx.execute(
+            r#"INSERT INTO sources (id, name, source_type, url, username, password, enabled, use_tvg_id, user_agent, max_streams, stream_user_agent, last_updated)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)"#,
+            params![
+                source.id, source.name, source.source_type, source.url,
+                source.username, source.password, source.enabled,
+                source.use_tvg_id, source.user_agent, source.max_streams,
+                source.stream_user_agent, source.last_updated
+            ],
+        )?;
+    }
+
+    // Restore groups
+    for group in &backup.groups {
+        tx.execute(
+            r#"INSERT INTO groups (id, name, image, source_id, hidden)
+               VALUES (?1, ?2, ?3, ?4, ?5)"#,
+            params![group.id, group.name, group.image, group.source_id, group.hidden],
+        )?;
+    }
+
+    // Restore seasons
+    for season in &backup.seasons {
+        tx.execute(
+            r#"INSERT INTO seasons (id, name, season_number, series_id, source_id, image)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+            params![season.id, season.name, season.season_number, season.series_id, season.source_id, season.image],
+        )?;
+    }
+
+    // Restore channels
+    for ch in &backup.channels {
+        tx.execute(
+            r#"INSERT INTO channels (id, name, image, url, media_type, source_id, favorite, series_id, group_id, stream_id, tv_archive, last_watched, season_id, episode_num, hidden)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL, ?12, ?13, ?14)"#,
+            params![
+                ch.id, ch.name, ch.image, ch.url, ch.media_type, ch.source_id,
+                ch.favorite, ch.series_id, ch.group_id, ch.stream_id,
+                ch.tv_archive, ch.season_id, ch.episode_num, ch.hidden
+            ],
+        )?;
+    }
+
+    // Restore channel headers
+    for h in &backup.channel_http_headers {
+        tx.execute(
+            r#"INSERT INTO channel_http_headers (id, channel_id, referrer, user_agent, http_origin, ignore_ssl)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+            params![h.id, h.channel_id, h.referrer, h.user_agent, h.http_origin, h.ignore_ssl],
+        )?;
+    }
+
+    // Restore EPG watchlist
+    for e in &backup.epg_watchlist {
+        tx.execute(
+            r#"INSERT INTO epg (epg_id, channel_name, title, start_timestamp)
+               VALUES (?1, ?2, ?3, ?4)"#,
+            params![e.epg_id, e.channel_name, e.title, e.start_timestamp],
+        )?;
+    }
+
+    tx.commit()?;
+
+    // Restore settings separately (uses the existing settings update path)
+    settings::update_settings(backup.settings)?;
+
+    Ok(())
+}
+
+fn import_merge(backup: Backup) -> Result<()> {
+    let mut conn = sql::get_conn()?;
+    let tx = conn.transaction()?;
+
+    // Build a mapping from backup source IDs to existing/new source IDs
+    let mut source_id_map: HashMap<i64, i64> = HashMap::new();
+
+    for source in &backup.sources {
+        let backup_id = source.id.unwrap_or(0);
+        // Check if source with same name + type exists
+        let existing: Option<i64> = tx.query_row(
+            "SELECT id FROM sources WHERE name = ?1 AND source_type = ?2",
+            params![source.name, source.source_type],
+            |row| row.get(0),
+        ).ok();
+
+        if let Some(existing_id) = existing {
+            source_id_map.insert(backup_id, existing_id);
+        } else {
+            tx.execute(
+                r#"INSERT INTO sources (name, source_type, url, username, password, enabled, use_tvg_id, user_agent, max_streams, stream_user_agent, last_updated)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"#,
+                params![
+                    source.name, source.source_type, source.url,
+                    source.username, source.password, source.enabled,
+                    source.use_tvg_id, source.user_agent, source.max_streams,
+                    source.stream_user_agent, source.last_updated
+                ],
+            )?;
+            let new_id = tx.last_insert_rowid();
+            source_id_map.insert(backup_id, new_id);
+        }
+    }
+
+    // Build group ID mapping
+    let mut group_id_map: HashMap<i64, i64> = HashMap::new();
+
+    for group in &backup.groups {
+        let backup_id = group.id.unwrap_or(0);
+        let mapped_source_id = group.source_id.and_then(|sid| source_id_map.get(&sid).copied());
+
+        let existing: Option<i64> = if let Some(sid) = mapped_source_id {
+            tx.query_row(
+                "SELECT id FROM groups WHERE name = ?1 AND source_id = ?2",
+                params![group.name, sid],
+                |row| row.get(0),
+            ).ok()
+        } else {
+            None
+        };
+
+        if let Some(existing_id) = existing {
+            group_id_map.insert(backup_id, existing_id);
+        } else {
+            tx.execute(
+                r#"INSERT INTO groups (name, image, source_id, hidden)
+                   VALUES (?1, ?2, ?3, ?4)"#,
+                params![group.name, group.image, mapped_source_id, group.hidden],
+            )?;
+            let new_id = tx.last_insert_rowid();
+            group_id_map.insert(backup_id, new_id);
+        }
+    }
+
+    // Import seasons (skip duplicates)
+    let mut season_id_map: HashMap<i64, i64> = HashMap::new();
+    for season in &backup.seasons {
+        let backup_id = season.id.unwrap_or(0);
+        let mapped_source_id = source_id_map.get(&season.source_id).copied().unwrap_or(season.source_id);
+
+        let existing: Option<i64> = tx.query_row(
+            "SELECT id FROM seasons WHERE season_number = ?1 AND series_id = ?2 AND source_id = ?3",
+            params![season.season_number, season.series_id, mapped_source_id],
+            |row| row.get(0),
+        ).ok();
+
+        if let Some(existing_id) = existing {
+            season_id_map.insert(backup_id, existing_id);
+        } else {
+            tx.execute(
+                r#"INSERT INTO seasons (name, season_number, series_id, source_id, image)
+                   VALUES (?1, ?2, ?3, ?4, ?5)"#,
+                params![season.name, season.season_number, season.series_id, mapped_source_id, season.image],
+            )?;
+            season_id_map.insert(backup_id, tx.last_insert_rowid());
+        }
+    }
+
+    // Import channels (skip duplicates by name+source_id)
+    for ch in &backup.channels {
+        let mapped_source_id = ch.source_id.and_then(|sid| source_id_map.get(&sid).copied());
+        let mapped_group_id = ch.group_id.and_then(|gid| group_id_map.get(&gid).copied());
+        let mapped_season_id = ch.season_id.and_then(|sid| season_id_map.get(&sid).copied());
+
+        if let Some(sid) = mapped_source_id {
+            let exists: bool = tx.query_row(
+                "SELECT 1 FROM channels WHERE name = ?1 AND source_id = ?2",
+                params![ch.name, sid],
+                |_| Ok(true),
+            ).unwrap_or(false);
+
+            if exists {
+                continue;
+            }
+        }
+
+        tx.execute(
+            r#"INSERT INTO channels (name, image, url, media_type, source_id, favorite, series_id, group_id, stream_id, tv_archive, season_id, episode_num, hidden)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"#,
+            params![
+                ch.name, ch.image, ch.url, ch.media_type, mapped_source_id,
+                ch.favorite, ch.series_id, mapped_group_id, ch.stream_id,
+                ch.tv_archive, mapped_season_id, ch.episode_num, ch.hidden
+            ],
+        )?;
+    }
+
+    tx.commit()?;
+
+    // Merge settings (update existing with backup values, keeping any not in backup)
+    settings::update_settings(backup.settings)?;
+
+    Ok(())
+}

--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -1,0 +1,96 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use reqwest::Client;
+
+use crate::{settings, types::Settings};
+
+const DEFAULT_USER_AGENT: &str = "Fred TV";
+
+/// Resolve the effective user-agent string from global settings, with an
+/// optional per-source override.
+pub fn resolve_user_agent(settings: &Settings, source_ua: Option<&str>) -> String {
+    source_ua
+        .filter(|s| !s.trim().is_empty())
+        .or(settings.user_agent.as_deref())
+        .unwrap_or(DEFAULT_USER_AGENT)
+        .to_string()
+}
+
+/// Build a base reqwest client with global settings applied (proxy, timeout).
+/// Does NOT set a user-agent; call `resolve_user_agent` separately and pass it
+/// to `.user_agent()` on the builder if needed.
+fn base_builder(settings: &Settings) -> Result<reqwest::ClientBuilder> {
+    let mut builder = Client::builder();
+
+    if let Some(proxy_url) = &settings.proxy {
+        if !proxy_url.trim().is_empty() {
+            let proxy = reqwest::Proxy::all(proxy_url)?;
+            builder = builder.proxy(proxy);
+        }
+    }
+
+    if let Some(timeout_secs) = settings.connection_timeout {
+        if timeout_secs > 0 {
+            let dur = Duration::from_secs(timeout_secs as u64);
+            builder = builder.timeout(dur).connect_timeout(dur);
+        }
+    }
+
+    Ok(builder)
+}
+
+/// Build a plain client with only global settings (UA, proxy, timeout).
+/// Used for simple one-off requests like WAN IP lookup.
+pub fn build_client() -> Result<Client> {
+    let settings = settings::get_settings()?;
+    let ua = resolve_user_agent(&settings, None);
+    Ok(base_builder(&settings)?.user_agent(ua).build()?)
+}
+
+/// Build a client configured for a specific source.
+/// Applies: source UA > global UA > default, plus proxy and timeout.
+pub fn build_client_for_source(source_ua: Option<&str>) -> Result<Client> {
+    let settings = settings::get_settings()?;
+    let ua = resolve_user_agent(&settings, source_ua);
+    Ok(base_builder(&settings)?.user_agent(ua).build()?)
+}
+
+/// Build a client configured for a specific channel with full header support.
+/// UA priority: channel headers > source stream_user_agent > source UA > global > default.
+/// Also applies Origin, Referer, and ignore-SSL from channel headers.
+pub fn build_client_for_channel(
+    source: &crate::types::Source,
+    headers: Option<&crate::types::ChannelHttpHeaders>,
+) -> Result<Client> {
+    let settings = settings::get_settings()?;
+
+    // UA priority chain
+    let channel_ua = headers.and_then(|h| h.user_agent.as_deref());
+    let source_stream_ua = source.stream_user_agent.as_deref();
+    let source_ua = source.user_agent.as_deref();
+    let ua = resolve_user_agent(
+        &settings,
+        channel_ua
+            .or(source_stream_ua)
+            .or(source_ua),
+    );
+
+    let mut builder = base_builder(&settings)?.user_agent(ua);
+
+    // Custom headers
+    let mut headers_map = reqwest::header::HeaderMap::new();
+    if let Some(h) = headers {
+        if let Some(origin) = h.http_origin.as_ref() {
+            headers_map.insert("Origin", reqwest::header::HeaderValue::from_str(origin)?);
+        }
+        if let Some(referrer) = h.referrer.as_ref() {
+            headers_map.insert("Referer", reqwest::header::HeaderValue::from_str(referrer)?);
+        }
+        if let Some(true) = h.ignore_ssl {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+    }
+
+    Ok(builder.default_headers(headers_map).build()?)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,11 +2,12 @@
 use anyhow::Context;
 use anyhow::Error;
 
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Manager, State};
 use tokio::sync::Mutex;
 use types::{
     AppState, Channel, CustomChannel, CustomChannelExtraData, EPG, EPGNotify, Filters, Group,
-    IdName, NetworkInfo, Settings, Source,
+    IdName, NetworkInfo, Settings, Source, StreamInfo,
 };
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use {
@@ -17,13 +18,18 @@ use {
     },
 };
 
+pub mod backup;
 pub mod bulk_action_type;
 pub mod epg;
+pub mod http;
+pub mod local_player;
 pub mod log;
 pub mod m3u;
 pub mod media_type;
 pub mod mpv;
+pub mod recording;
 pub mod restream;
+pub mod scheduler;
 pub mod settings;
 pub mod share;
 pub mod sort_type;
@@ -113,15 +119,29 @@ pub fn run() {
             hide_channel,
             hide_group,
             remove_from_history,
+            get_stream_info,
+            start_local_stream,
+            stop_local_stream,
+            start_recording,
+            stop_recording,
+            get_active_recordings,
+            restart_scheduler,
+            export_backup,
+            import_backup,
         ])
         .setup(|app| {
-            app.manage(Mutex::new(AppState {
-                ..Default::default()
-            }));
+            let mut state = AppState::default();
+            let (epg_stop, source_stop) = scheduler::start_scheduler(app.handle().clone());
+            state.epg_refresh_stop = epg_stop;
+            state.source_refresh_stop = source_stop;
+            app.manage(Mutex::new(state));
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             if *ENABLE_TRAY_ICON {
                 let _ = build_tray_icon(app);
             }
+            // HardwareAccelerationPolicy left at default (OnDemand)
+            // so WebKitGTK only GPU-composites when needed (video playback)
+            // rather than spinning the compositor for all UI content
             Ok(())
         })
         .on_window_event(|_window, event| match event {
@@ -147,6 +167,20 @@ pub fn run() {
                 let window = _app.get_webview_window("main").expect("no main window");
                 let _ = window.show();
                 let _ = window.set_focus();
+            }
+            tauri::RunEvent::ExitRequested { .. } => {
+                // Signal all background processes to stop so they don't become orphans
+                let state: State<Mutex<AppState>> = _app.state();
+                if let Ok(state) = state.try_lock() {
+                    state.notify_stop.store(true, Ordering::Relaxed);
+                    state.restream_stop_signal.store(true, Ordering::Relaxed);
+                    state.local_player_stop.store(true, Ordering::Relaxed);
+                    state.epg_refresh_stop.store(true, Ordering::Relaxed);
+                    state.source_refresh_stop.store(true, Ordering::Relaxed);
+                    for rec in state.active_recordings.values() {
+                        rec.stop_signal.store(true, Ordering::Relaxed);
+                    }
+                }
             }
             _ => {}
         });
@@ -560,4 +594,79 @@ async fn cancel_play(
     mpv::cancel_play(source_id, channel_id.to_string(), state)
         .await
         .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn get_stream_info(channel: Channel) -> Result<StreamInfo, String> {
+    local_player::get_stream_info(&channel).await.map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn start_local_stream(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String, String> {
+    local_player::start_local_stream(channel, state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn stop_local_stream(state: State<'_, Mutex<AppState>>) -> Result<(), String> {
+    local_player::stop_local_stream(state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn start_recording(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<recording::RecordingInfo, String> {
+    recording::start_recording(channel, state, app)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn stop_recording(
+    recording_id: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String, String> {
+    recording::stop_recording(recording_id, state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn get_active_recordings(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<recording::RecordingInfo>, String> {
+    recording::get_active_recordings(state)
+        .await
+        .map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn restart_scheduler(
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let mut state = state.lock().await;
+    let (epg_stop, source_stop) =
+        scheduler::restart_scheduler(app, &state.epg_refresh_stop, &state.source_refresh_stop);
+    state.epg_refresh_stop = epg_stop;
+    state.source_refresh_stop = source_stop;
+    Ok(())
+}
+
+#[tauri::command(async)]
+fn export_backup(path: String) -> Result<(), String> {
+    backup::export_backup(path).map_err(map_err_frontend)
+}
+
+#[tauri::command(async)]
+fn import_backup(path: String, mode: String) -> Result<(), String> {
+    backup::import_backup(path, mode).map_err(map_err_frontend)
 }

--- a/src-tauri/src/local_player.rs
+++ b/src-tauri/src/local_player.rs
@@ -1,0 +1,341 @@
+use std::{
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+use anyhow::{Context, Result};
+use tauri::State;
+use tokio::sync::{
+    broadcast,
+    Mutex,
+    oneshot::{self, Sender},
+};
+use warp::Filter;
+
+use crate::{
+    sql,
+    types::{AppState, Channel, StreamInfo},
+    utils::get_bin,
+};
+
+const FFMPEG_BIN_NAME: &str = "ffmpeg";
+const DEFAULT_LOCAL_PLAYER_PORT: u16 = 9321;
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+pub async fn get_stream_info(channel: &Channel) -> Result<StreamInfo> {
+    let url = channel.url.clone().context("no channel url")?;
+    let channel_id = channel.id.context("no channel id")?;
+    let headers = sql::get_channel_headers_by_id(channel_id)?;
+
+    // Also check if the source has a stream_user_agent set
+    let source_has_ua = channel
+        .source_id
+        .and_then(|sid| sql::get_source_from_id(sid).ok())
+        .and_then(|s| s.stream_user_agent)
+        .is_some();
+
+    let has_custom_headers = source_has_ua
+        || headers
+            .as_ref()
+            .map(|h| {
+                h.referrer.is_some()
+                    || h.user_agent.is_some()
+                    || h.http_origin.is_some()
+                    || h.ignore_ssl == Some(true)
+            })
+            .unwrap_or(false);
+    let url_path = url.split('?').next().unwrap_or(&url);
+    let mut is_hls = url_path.ends_with(".m3u8") || url_path.ends_with(".m3u");
+    let mut resolved_url: Option<String> = None;
+
+    // For non-HLS URLs without custom headers, follow redirects to check
+    // if the final URL is actually an HLS stream (e.g. tvpass.org -> .m3u8)
+    if !is_hls && !has_custom_headers {
+        if let Ok(client) = crate::http::build_client() {
+            if let Ok(resp) = client
+                .head(&url)
+                .timeout(std::time::Duration::from_secs(5))
+                .send()
+                .await
+            {
+                let final_url = resp.url().to_string();
+                let fp = final_url.split('?').next().unwrap_or(&final_url);
+                if fp.ends_with(".m3u8") || fp.ends_with(".m3u") {
+                    is_hls = true;
+                    resolved_url = Some(final_url);
+                }
+            }
+        }
+    }
+
+    Ok(StreamInfo {
+        url,
+        has_custom_headers,
+        is_hls,
+        resolved_url,
+    })
+}
+
+/// Start ffmpeg outputting raw MPEG-TS to stdout, returning the child process
+/// and a broadcast sender that streams the TS data.
+fn start_ffmpeg_streaming(
+    channel: Channel,
+    log_path: PathBuf,
+) -> Result<(Child, broadcast::Sender<bytes::Bytes>)> {
+    let headers = sql::get_channel_headers_by_id(channel.id.context("no channel id")?)?;
+    let log_file = std::fs::File::create(&log_path).ok();
+    eprintln!("[local_player] ffmpeg log: {:?}", log_path);
+
+    let mut command = Command::new(get_bin(FFMPEG_BIN_NAME));
+    if let Some(headers) = headers {
+        if let Some(referrer) = headers.referrer {
+            command.arg("-headers");
+            command.arg(format!("Referer: {referrer}"));
+        }
+        if let Some(user_agent) = headers.user_agent {
+            command.arg("-headers");
+            command.arg(format!("User-Agent: {user_agent}"));
+        }
+        if let Some(origin) = headers.http_origin {
+            command.arg("-headers");
+            command.arg(format!("Origin: {origin}"));
+        }
+        if let Some(ignore_ssl) = headers.ignore_ssl {
+            if ignore_ssl {
+                command.arg("-tls_verify");
+                command.arg("0");
+            }
+        }
+    }
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let mut child = command
+        .arg("-fflags")
+        .arg("+genpts+discardcorrupt")
+        .arg("-analyzeduration")
+        .arg("1000000")
+        .arg("-probesize")
+        .arg("2000000")
+        .arg("-reconnect")
+        .arg("1")
+        .arg("-reconnect_at_eof")
+        .arg("1")
+        .arg("-reconnect_streamed")
+        .arg("1")
+        .arg("-reconnect_on_network_error")
+        .arg("1")
+        .arg("-reconnect_delay_max")
+        .arg("5")
+        .arg("-i")
+        .arg(channel.url.context("no channel url")?)
+        .arg("-c")
+        .arg("copy")
+        .arg("-f")
+        .arg("mpegts")
+        .arg("-mpegts_flags")
+        .arg("resend_headers")
+        .arg("-pat_period")
+        .arg("0.1")
+        .arg("-sdt_period")
+        .arg("0.1")
+        .arg("pipe:1")
+        .stdout(Stdio::piped())
+        .stderr(log_file.map(Stdio::from).unwrap_or_else(Stdio::null))
+        .spawn()?;
+
+    let stdout = child.stdout.take().context("no stdout from ffmpeg")?;
+    let (tx, _) = broadcast::channel::<bytes::Bytes>(512);
+    let tx_writer = tx.clone();
+
+    // Blocking reader thread: reads ffmpeg stdout and broadcasts chunks.
+    // Exits naturally when ffmpeg is killed (stdout closes).
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut stdout = stdout;
+        let mut buf = vec![0u8; 65536];
+        loop {
+            match stdout.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = tx_writer.send(bytes::Bytes::copy_from_slice(&buf[..n]));
+                }
+                Err(_) => break,
+            }
+        }
+        eprintln!("[local_player] stdout reader exited");
+    });
+
+    Ok((child, tx))
+}
+
+/// Start a warp server that streams MPEG-TS data from the broadcast channel.
+async fn start_streaming_server(
+    tx: broadcast::Sender<bytes::Bytes>,
+    port: u16,
+) -> Result<(Sender<bool>, tokio::task::JoinHandle<()>)> {
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_methods(vec!["GET", "HEAD", "OPTIONS"])
+        .allow_headers(vec!["Range", "Content-Type"]);
+
+    let stream_route = warp::path("stream")
+        .and(warp::get())
+        .map(move || {
+            let (mut body_tx, body) = hyper::Body::channel();
+            let mut rx = tx.subscribe();
+            tokio::spawn(async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(chunk) => {
+                            if body_tx.send_data(chunk).await.is_err() {
+                                break; // Client disconnected
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            eprintln!("[local_player] stream consumer lagged, skipped {} chunks", n);
+                            continue;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                eprintln!("[local_player] stream consumer exited");
+            });
+            warp::http::Response::builder()
+                .header("Content-Type", "video/mp2t")
+                .header("Cache-Control", "no-cache, no-store")
+                .body(body)
+                .unwrap()
+        });
+
+    let routes = stream_route.with(cors);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<bool>();
+    let (_, server) =
+        warp::serve(routes).bind_with_graceful_shutdown(([127, 0, 0, 1], port), async {
+            shutdown_rx.await.ok();
+        });
+    let handle = tokio::spawn(server);
+    Ok((shutdown_tx, handle))
+}
+
+fn get_local_player_folder() -> Result<PathBuf> {
+    let mut path = directories::ProjectDirs::from("dev", "fredol", "open-tv")
+        .context("can't find project folder")?
+        .cache_dir()
+        .to_owned();
+    path.push("local_player");
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    Ok(path)
+}
+
+/// Kill any orphaned ffmpeg processes from previous app sessions.
+fn kill_orphaned_ffmpeg() {
+    #[cfg(unix)]
+    {
+        // Match ffmpeg processes outputting mpegts to pipe:1 (our signature)
+        let _ = Command::new("pkill")
+            .arg("-9")
+            .arg("-f")
+            .arg("ffmpeg.*-f mpegts.*pipe:1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        // Also kill any old-style ffmpegs writing to our cache directory
+        if let Ok(cache_dir) = get_local_player_folder() {
+            let pattern = cache_dir.join("stream.m3u8").to_string_lossy().to_string();
+            let _ = Command::new("pkill")
+                .arg("-9")
+                .arg("-f")
+                .arg(&pattern)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub async fn start_local_stream(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String> {
+    // Signal old monitor to stop, then await its full cleanup
+    let (stop, old_monitor) = {
+        let mut s = state.lock().await;
+        let stop = s.local_player_stop.clone();
+        let monitor = s.local_player_monitor.take();
+        (stop, monitor)
+    };
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    if let Some(handle) = old_monitor {
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+    stop.store(false, std::sync::atomic::Ordering::Relaxed);
+
+    kill_orphaned_ffmpeg();
+
+    let cache_dir = get_local_player_folder()?;
+    let log_path = cache_dir.join("ffmpeg.log");
+
+    let port = DEFAULT_LOCAL_PLAYER_PORT;
+    {
+        let mut s = state.lock().await;
+        s.local_player_port = Some(port);
+    }
+
+    let (mut ffmpeg_child, broadcast_tx) = start_ffmpeg_streaming(channel, log_path)?;
+    eprintln!("[local_player] ffmpeg started, pid={}", ffmpeg_child.id());
+
+    let (web_tx, web_handle) = start_streaming_server(broadcast_tx, port).await?;
+    eprintln!("[local_player] streaming server started on port {}", port);
+
+    let local_url = format!("http://127.0.0.1:{port}/stream");
+    eprintln!("[local_player] returning url: {}", local_url);
+
+    let monitor_handle = tokio::spawn(async move {
+        while !stop.load(std::sync::atomic::Ordering::Relaxed)
+            && ffmpeg_child
+                .try_wait()
+                .map(|opt| opt.is_none())
+                .unwrap_or(true)
+            && !web_handle.is_finished()
+        {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        let stop_val = stop.load(std::sync::atomic::Ordering::Relaxed);
+        let ffmpeg_exited = ffmpeg_child
+            .try_wait()
+            .map(|opt| opt.is_some())
+            .unwrap_or(false);
+        let web_finished = web_handle.is_finished();
+        eprintln!(
+            "[local_player] monitor exiting: stop={}, ffmpeg_exited={}, web_finished={}",
+            stop_val, ffmpeg_exited, web_finished
+        );
+        let _ = ffmpeg_child.kill();
+        let _ = web_tx.send(true);
+        let _ = ffmpeg_child.wait();
+        let _ = web_handle.await;
+        eprintln!("[local_player] cleanup done");
+    });
+    {
+        let mut s = state.lock().await;
+        s.local_player_monitor = Some(monitor_handle);
+    }
+
+    Ok(local_url)
+}
+
+pub async fn stop_local_stream(state: State<'_, Mutex<AppState>>) -> Result<()> {
+    let s = state.lock().await;
+    s.local_player_stop
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}

--- a/src-tauri/src/m3u.rs
+++ b/src-tauri/src/m3u.rs
@@ -16,7 +16,6 @@ use crate::{
     log, media_type, source_type,
     sql::{self, set_channel_group_id},
     types::{self, ChannelHttpHeaders},
-    utils::get_user_agent_from_source,
 };
 
 static NAME_REGEX: LazyLock<Regex> =
@@ -171,8 +170,7 @@ fn commit_channel(
 }
 
 pub async fn get_m3u8_from_link(source: Source, wipe: bool) -> Result<()> {
-    let user_agent = get_user_agent_from_source(&source)?;
-    let client = reqwest::Client::builder().user_agent(user_agent).build()?;
+    let client = crate::http::build_client_for_source(source.user_agent.as_deref())?;
     let url = source.url.clone().context("Invalid source")?;
     let mut response = client.get(&url).send().await?;
     if !response.status().is_success() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,17 @@ pub fn apply_gpu_fixes() {
         unsafe {
             env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
+    } else {
+        // Enable VA-API hardware video decoding in WebKitGTK
+        // WebKitGTK disables VAAPI decoders by default
+        eprintln!("Non-NVIDIA GPU: enabling VA-API hardware video decode");
+        unsafe {
+            env::set_var("WEBKIT_GST_ENABLE_LEGACY_VAAPI", "1");
+            env::set_var(
+                "GST_PLUGIN_FEATURE_RANK",
+                "vaapih264dec:MAX,vaapih265dec:MAX,vah264dec:MAX,vah265dec:MAX",
+            );
+        }
     }
 }
 

--- a/src-tauri/src/recording.rs
+++ b/src-tauri/src/recording.rs
@@ -1,0 +1,272 @@
+use std::{
+    io::{Read as _, Write},
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+use anyhow::{Context, Result};
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::Mutex;
+
+use crate::{
+    settings::{get_default_record_path, get_settings},
+    sql,
+    types::{ActiveRecording, AppState, Channel},
+    utils::{get_bin, sanitize},
+};
+
+const FFMPEG_BIN_NAME: &str = "ffmpeg";
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecordingInfo {
+    pub recording_id: String,
+    pub channel_id: i64,
+    pub channel_name: String,
+    pub channel_image: Option<String>,
+    pub file_path: String,
+    pub start_timestamp: u64,
+}
+
+fn make_recording_id(channel_id: i64) -> String {
+    let epoch_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("rec-{channel_id}-{epoch_ms}")
+}
+
+fn build_output_path(channel_name: &str) -> Result<String> {
+    let settings = get_settings().ok();
+    let dir = settings
+        .and_then(|s| s.recording_path)
+        .unwrap_or_else(|| get_default_record_path().unwrap_or_else(|_| "/tmp".to_string()));
+    std::fs::create_dir_all(&dir)?;
+    let sanitized = sanitize(channel_name.to_string());
+    let timestamp = Local::now().format("%Y-%m-%d-%H-%M-%S");
+    let filename = format!("{sanitized}_{timestamp}.mp4");
+    let mut path = std::path::PathBuf::from(dir);
+    path.push(filename);
+    Ok(path.to_string_lossy().to_string())
+}
+
+fn spawn_recording_ffmpeg(channel: &Channel) -> Result<(Child, String)> {
+    let url = channel.url.clone().context("no channel url")?;
+    let channel_id = channel.id.context("no channel id")?;
+    let output_path = build_output_path(&channel.name)?;
+
+    let headers = sql::get_channel_headers_by_id(channel_id)?;
+    let source_ua = channel
+        .source_id
+        .and_then(|sid| sql::get_source_from_id(sid).ok())
+        .and_then(|s| s.stream_user_agent);
+
+    let mut command = Command::new(get_bin(FFMPEG_BIN_NAME));
+
+    if let Some(headers) = &headers {
+        if let Some(referrer) = &headers.referrer {
+            command.arg("-headers");
+            command.arg(format!("Referer: {referrer}"));
+        }
+        let ua = headers.user_agent.as_ref().or(source_ua.as_ref());
+        if let Some(user_agent) = ua {
+            command.arg("-headers");
+            command.arg(format!("User-Agent: {user_agent}"));
+        }
+        if let Some(origin) = &headers.http_origin {
+            command.arg("-headers");
+            command.arg(format!("Origin: {origin}"));
+        }
+        if let Some(true) = headers.ignore_ssl {
+            command.arg("-tls_verify");
+            command.arg("0");
+        }
+    } else if let Some(ua) = &source_ua {
+        command.arg("-headers");
+        command.arg(format!("User-Agent: {ua}"));
+    }
+
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let child = command
+        .arg("-fflags")
+        .arg("+genpts+discardcorrupt")
+        .arg("-analyzeduration")
+        .arg("2000000")
+        .arg("-probesize")
+        .arg("5000000")
+        .arg("-reconnect")
+        .arg("1")
+        .arg("-reconnect_at_eof")
+        .arg("1")
+        .arg("-reconnect_streamed")
+        .arg("1")
+        .arg("-reconnect_on_network_error")
+        .arg("1")
+        .arg("-reconnect_delay_max")
+        .arg("5")
+        .arg("-i")
+        .arg(&url)
+        .arg("-c")
+        .arg("copy")
+        .arg("-movflags")
+        .arg("+faststart")
+        .arg("-y")
+        .arg(&output_path)
+        .arg("-nostats")
+        .arg("-loglevel")
+        .arg("warning")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    Ok((child, output_path))
+}
+
+pub async fn start_recording(
+    channel: Channel,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<RecordingInfo> {
+    let channel_id = channel.id.context("no channel id")?;
+    let recording_id = make_recording_id(channel_id);
+
+    let (child, file_path) = spawn_recording_ffmpeg(&channel)?;
+
+    let start_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let info = RecordingInfo {
+        recording_id: recording_id.clone(),
+        channel_id,
+        channel_name: channel.name.clone(),
+        channel_image: channel.image.clone(),
+        file_path,
+        start_timestamp,
+    };
+
+    let stop_signal = Arc::new(AtomicBool::new(false));
+
+    {
+        let mut guard = state.lock().await;
+        guard.active_recordings.insert(
+            recording_id.clone(),
+            ActiveRecording {
+                info: info.clone(),
+                stop_signal: stop_signal.clone(),
+            },
+        );
+    }
+
+    let _ = app.emit("recording-started", &info);
+
+    // Spawn monitor task
+    let monitor_id = recording_id.clone();
+    let monitor_info = info.clone();
+    let monitor_app = app.clone();
+    tokio::spawn(async move {
+        let state: tauri::State<'_, Mutex<AppState>> = monitor_app.state();
+        monitor_recording(child, stop_signal, monitor_id, monitor_info, state, monitor_app.clone()).await;
+    });
+
+    Ok(info)
+}
+
+async fn monitor_recording(
+    mut child: Child,
+    stop_signal: Arc<AtomicBool>,
+    recording_id: String,
+    info: RecordingInfo,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        if stop_signal.load(Ordering::Relaxed) {
+            // Graceful shutdown: write 'q' to ffmpeg's stdin so it finalizes the moov atom
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(b"q\n");
+                let _ = stdin.flush();
+                drop(stdin);
+            }
+            // Wait up to 5 seconds for ffmpeg to finalize and exit
+            let mut exited = false;
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                if let Ok(Some(_)) = child.try_wait() {
+                    exited = true;
+                    break;
+                }
+            }
+            // Force kill only as a last resort
+            if !exited {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            break;
+        }
+
+        match child.try_wait() {
+            Ok(Some(_)) => break, // process exited
+            Ok(None) => continue, // still running
+            Err(_) => break,
+        }
+    }
+
+    // Log any ffmpeg warnings/errors after exit
+    if let Some(mut stderr) = child.stderr.take() {
+        let mut buf = String::new();
+        if stderr.read_to_string(&mut buf).is_ok() && !buf.trim().is_empty() {
+            let truncated = &buf[..buf.len().min(2000)];
+            crate::log::log(format!("Recording ffmpeg output for {}: {}", info.channel_name, truncated));
+        }
+    }
+
+    {
+        let mut guard = state.lock().await;
+        guard.active_recordings.remove(&recording_id);
+    }
+
+    let _ = app.emit("recording-stopped", &info);
+}
+
+pub async fn stop_recording(
+    recording_id: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<String> {
+    let guard = state.lock().await;
+    let recording = guard
+        .active_recordings
+        .get(&recording_id)
+        .context("recording not found")?;
+    recording.stop_signal.store(true, Ordering::Relaxed);
+    let path = recording.info.file_path.clone();
+    Ok(path)
+}
+
+pub async fn get_active_recordings(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<RecordingInfo>> {
+    let guard = state.lock().await;
+    let recordings: Vec<RecordingInfo> = guard
+        .active_recordings
+        .values()
+        .map(|r| r.info.clone())
+        .collect();
+    Ok(recordings)
+}

--- a/src-tauri/src/restream.rs
+++ b/src-tauri/src/restream.rs
@@ -221,8 +221,9 @@ fn get_ips(port: u16) -> Result<Vec<String>> {
 }
 
 async fn get_wan_ip(port: u16) -> Result<String> {
+    let client = crate::http::build_client()?;
     Ok(format!(
         "http://{}:{port}/stream.m3u8",
-        reqwest::get(WAN_IP_API).await?.text().await?
+        client.get(WAN_IP_API).send().await?.text().await?
     ))
 }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -1,0 +1,90 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter};
+
+use crate::{log, settings, utils};
+
+/// Start background refresh timers based on current settings.
+/// Spawns up to two tokio tasks (EPG + source refresh).
+/// Returns stop signals so callers can cancel them.
+pub fn start_scheduler(app: AppHandle) -> (Arc<AtomicBool>, Arc<AtomicBool>) {
+    let epg_stop = Arc::new(AtomicBool::new(false));
+    let source_stop = Arc::new(AtomicBool::new(false));
+
+    let settings = match settings::get_settings() {
+        Ok(s) => s,
+        Err(e) => {
+            log::log(format!("Scheduler: failed to read settings: {:?}", e));
+            return (epg_stop, source_stop);
+        }
+    };
+
+    // EPG auto-refresh
+    if let Some(hours) = settings.epg_refresh_interval {
+        if hours > 0 {
+            let stop = epg_stop.clone();
+            let app = app.clone();
+            tokio::spawn(async move {
+                let interval = Duration::from_secs(hours as u64 * 3600);
+                loop {
+                    tokio::time::sleep(interval).await;
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    log::log("Scheduler: auto-refreshing sources (EPG interval)".to_string());
+                    match utils::refresh_all().await {
+                        Ok(_) => {
+                            let _ = app.emit("sources-refreshed", ());
+                        }
+                        Err(e) => {
+                            log::log(format!("Scheduler: EPG refresh failed: {:?}", e));
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    // Source auto-refresh
+    if let Some(hours) = settings.source_refresh_interval {
+        if hours > 0 {
+            let stop = source_stop.clone();
+            let app = app.clone();
+            tokio::spawn(async move {
+                let interval = Duration::from_secs(hours as u64 * 3600);
+                loop {
+                    tokio::time::sleep(interval).await;
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    log::log("Scheduler: auto-refreshing sources (source interval)".to_string());
+                    match utils::refresh_all().await {
+                        Ok(_) => {
+                            let _ = app.emit("sources-refreshed", ());
+                        }
+                        Err(e) => {
+                            log::log(format!("Scheduler: source refresh failed: {:?}", e));
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    (epg_stop, source_stop)
+}
+
+/// Restart the scheduler. Signals old tasks to stop, starts new ones.
+pub fn restart_scheduler(
+    app: AppHandle,
+    old_epg_stop: &Arc<AtomicBool>,
+    old_source_stop: &Arc<AtomicBool>,
+) -> (Arc<AtomicBool>, Arc<AtomicBool>) {
+    old_epg_stop.store(true, Ordering::Relaxed);
+    old_source_stop.store(true, Ordering::Relaxed);
+    start_scheduler(app)
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -18,6 +18,13 @@ pub const DEFAULT_SORT: &str = "defaultSort";
 pub const ENABLE_HWDEC: &str = "enableHWDEC";
 pub const ALWAYS_ASK_SAVE: &str = "alwaysAskSave";
 pub const ENABLE_GPU: &str = "enableGPU";
+pub const PLAYER_ENGINE: &str = "playerEngine";
+pub const USER_AGENT: &str = "userAgent";
+pub const PROXY: &str = "proxy";
+pub const CONNECTION_TIMEOUT: &str = "connectionTimeout";
+pub const EPG_REFRESH_INTERVAL: &str = "epgRefreshInterval";
+pub const SOURCE_REFRESH_INTERVAL: &str = "sourceRefreshInterval";
+pub const BUFFER_SIZE: &str = "bufferSize";
 
 pub fn get_settings() -> Result<Settings> {
     let map = sql::get_settings()?;
@@ -39,12 +46,19 @@ pub fn get_settings() -> Result<Settings> {
         enable_hwdec: map.get(ENABLE_HWDEC).and_then(|s| s.parse().ok()),
         always_ask_save: map.get(ALWAYS_ASK_SAVE).and_then(|s| s.parse().ok()),
         enable_gpu: map.get(ENABLE_GPU).and_then(|s| s.parse().ok()),
+        player_engine: map.get(PLAYER_ENGINE).and_then(|s| s.parse().ok()),
+        user_agent: map.get(USER_AGENT).map(|s| s.to_string()),
+        proxy: map.get(PROXY).map(|s| s.to_string()),
+        connection_timeout: map.get(CONNECTION_TIMEOUT).and_then(|s| s.parse().ok()),
+        epg_refresh_interval: map.get(EPG_REFRESH_INTERVAL).and_then(|s| s.parse().ok()),
+        source_refresh_interval: map.get(SOURCE_REFRESH_INTERVAL).and_then(|s| s.parse().ok()),
+        buffer_size: map.get(BUFFER_SIZE).and_then(|s| s.parse().ok()),
     };
     Ok(settings)
 }
 
 pub fn update_settings(settings: Settings) -> Result<()> {
-    let mut map: HashMap<String, Option<String>> = HashMap::with_capacity(13);
+    let mut map: HashMap<String, Option<String>> = HashMap::with_capacity(20);
 
     map.insert(MPV_PARAMS.to_string(), settings.mpv_params);
 
@@ -89,6 +103,23 @@ pub fn update_settings(settings: Settings) -> Result<()> {
     }
     if let Some(gpu) = settings.enable_gpu {
         map.insert(ENABLE_GPU.to_string(), Some(gpu.to_string()));
+    }
+    if let Some(engine) = settings.player_engine {
+        map.insert(PLAYER_ENGINE.to_string(), Some(engine.to_string()));
+    }
+    map.insert(USER_AGENT.to_string(), settings.user_agent);
+    map.insert(PROXY.to_string(), settings.proxy);
+    if let Some(timeout) = settings.connection_timeout {
+        map.insert(CONNECTION_TIMEOUT.to_string(), Some(timeout.to_string()));
+    }
+    if let Some(epg_interval) = settings.epg_refresh_interval {
+        map.insert(EPG_REFRESH_INTERVAL.to_string(), Some(epg_interval.to_string()));
+    }
+    if let Some(source_interval) = settings.source_refresh_interval {
+        map.insert(SOURCE_REFRESH_INTERVAL.to_string(), Some(source_interval.to_string()));
+    }
+    if let Some(buf) = settings.buffer_size {
+        map.insert(BUFFER_SIZE.to_string(), Some(buf.to_string()));
     }
     sql::update_settings(map)?;
     Ok(())

--- a/src-tauri/src/sql.rs
+++ b/src-tauri/src/sql.rs
@@ -464,7 +464,8 @@ pub fn search(filters: Filters) -> Result<Vec<Channel>> {
         return search_series(filters);
     }
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let media_types = match filters.series_id.is_some() {
         true => vec![1],
         false => filters.media_types.clone().unwrap(),
@@ -544,7 +545,8 @@ pub fn search(filters: Filters) -> Result<Vec<Channel>> {
 
 fn search_series(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let query = filters.query.unwrap_or("".to_string());
     let keywords: Vec<String> = match filters.use_keywords {
         true => query
@@ -816,7 +818,8 @@ fn apply_bulk_channels(
 
 fn search_hidden(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
 
     let media_types = match filters.series_id.is_some() {
         true => vec![1],
@@ -928,7 +931,8 @@ fn to_sql_like(query: Option<String>) -> String {
 
 pub fn search_group(filters: Filters) -> Result<Vec<Channel>> {
     let sql = get_conn()?;
-    let offset: u16 = filters.page as u16 * PAGE_SIZE as u16 - PAGE_SIZE as u16;
+    let page = (filters.page as u16).max(1);
+    let offset: u16 = page * PAGE_SIZE as u16 - PAGE_SIZE as u16;
     let query = filters.query.unwrap_or("".to_string());
     let media_types = filters.media_types.context("no media types")?;
     let keywords: Vec<String> = match filters.use_keywords {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -83,6 +83,13 @@ pub struct Settings {
     pub enable_hwdec: Option<bool>,
     pub always_ask_save: Option<bool>,
     pub enable_gpu: Option<bool>,
+    pub player_engine: Option<u8>,
+    pub user_agent: Option<String>,
+    pub proxy: Option<String>,
+    pub connection_timeout: Option<u16>,
+    pub epg_refresh_interval: Option<u16>,
+    pub source_refresh_interval: Option<u16>,
+    pub buffer_size: Option<u8>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
@@ -175,13 +182,34 @@ pub struct EPGNotify {
     pub channel_name: String,
 }
 
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct StreamInfo {
+    pub url: String,
+    pub has_custom_headers: bool,
+    pub is_hls: bool,
+    pub resolved_url: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ActiveRecording {
+    pub info: crate::recording::RecordingInfo,
+    pub stop_signal: Arc<AtomicBool>,
+}
+
 #[derive(Debug, Default)]
 pub struct AppState {
     pub notify_stop: Arc<AtomicBool>,
     pub thread_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
     pub restream_stop_signal: Arc<AtomicBool>,
+    pub local_player_stop: Arc<AtomicBool>,
+    pub local_player_port: Option<u16>,
+    pub local_player_monitor: Option<tokio::task::JoinHandle<()>>,
 
     pub play_stop: HashMap<i64, IndexMap<String, CancellationToken>>,
+    pub active_recordings: HashMap<String, ActiveRecording>,
+
+    pub epg_refresh_stop: Arc<AtomicBool>,
+    pub source_refresh_stop: Arc<AtomicBool>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -12,10 +12,6 @@ use chrono::{DateTime, Local, Utc};
 use directories::ProjectDirs;
 use indexmap::IndexMap;
 use regex::Regex;
-use reqwest::{
-    Client,
-    header::{HeaderMap, HeaderValue},
-};
 use serde::Serialize;
 use std::{
     env::{consts::OS, current_exe},
@@ -35,7 +31,6 @@ const MACOS_POTENTIAL_PATHS: [&str; 3] = [
     "/usr/local/bin",    // Homebrew on AMD64 Mac
 ];
 
-const DEFAULT_USER_AGENT: &str = "Fred TV";
 
 static ILLEGAL_CHARS_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"[<>:"/\\|?*\x00-\x1F]"#).unwrap());
@@ -89,29 +84,7 @@ pub async fn download(
         .map_err(|e| log(format!("{:?}", e)));
 
     let headers = sql::get_channel_headers_by_id(channel.id.context("no channel id?")?)?;
-    let mut client = Client::builder();
-    let mut headers_map = HeaderMap::new();
-    if let Some(headers) = headers.as_ref() {
-        if let Some(origin) = headers.http_origin.as_ref() {
-            headers_map.insert("Origin", HeaderValue::from_str(origin)?);
-        }
-        if let Some(referrer) = headers.referrer.as_ref() {
-            headers_map.insert("Referer", HeaderValue::from_str(referrer)?);
-        }
-        if let Some(ignore_ssl) = headers.ignore_ssl {
-            if ignore_ssl {
-                client = client.danger_accept_invalid_certs(true);
-            }
-        }
-    }
-    let user_agent = headers
-        .and_then(|f| f.user_agent)
-        .or(source.stream_user_agent)
-        .unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
-    let client = client
-        .user_agent(user_agent)
-        .default_headers(headers_map)
-        .build()?;
+    let client = crate::http::build_client_for_channel(&source, headers.as_ref())?;
     let url = channel.url.clone().context("no url provided")?;
     let name = channel.name.clone();
     let mut response = client.get(&url).send().await?;
@@ -340,15 +313,6 @@ pub fn check_nuke() -> Result<()> {
         std::fs::remove_file(path)?;
     }
     Ok(())
-}
-
-pub fn get_user_agent_from_source(source: &Source) -> Result<String> {
-    let user_agent: &str = source
-        .user_agent
-        .as_deref()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or(DEFAULT_USER_AGENT);
-    Ok(user_agent.to_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/xtream.rs
+++ b/src-tauri/src/xtream.rs
@@ -8,7 +8,7 @@ use crate::types::EPG;
 use crate::types::Season;
 use crate::types::Source;
 use crate::utils::get_local_time;
-use crate::utils::get_user_agent_from_source;
+use crate::http;
 use anyhow::anyhow;
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -130,21 +130,21 @@ fn build_xtream_url(source: &mut Source) -> Result<Url> {
 
 pub async fn get_xtream(mut source: Source, wipe: bool) -> Result<()> {
     let url = build_xtream_url(&mut source)?;
-    let user_agent = get_user_agent_from_source(&source)?;
+    let client = http::build_client_for_source(source.user_agent.as_deref())?;
     let (live, live_cats, vods, vods_cats, series, series_cats) = join!(
-        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_LIVE_STREAMS, &user_agent),
+        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_LIVE_STREAMS, &client),
         get_xtream_http_data::<Vec<XtreamCategory>>(
             url.clone(),
             GET_LIVE_STREAM_CATEGORIES,
-            &user_agent
+            &client
         ),
-        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_VODS, &user_agent),
-        get_xtream_http_data::<Vec<XtreamCategory>>(url.clone(), GET_VOD_CATEGORIES, &user_agent),
-        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_SERIES, &user_agent),
+        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_VODS, &client),
+        get_xtream_http_data::<Vec<XtreamCategory>>(url.clone(), GET_VOD_CATEGORIES, &client),
+        get_xtream_http_data::<Vec<XtreamStream>>(url.clone(), GET_SERIES, &client),
         get_xtream_http_data::<Vec<XtreamCategory>>(
             url.clone(),
             GET_SERIES_CATEGORIES,
-            &user_agent
+            &client
         ),
     );
     let mut sql = sql::get_conn()?;
@@ -193,11 +193,10 @@ pub async fn get_xtream(mut source: Source, wipe: bool) -> Result<()> {
     Ok(())
 }
 
-async fn get_xtream_http_data<T>(mut url: Url, action: &str, user_agent: &String) -> Result<T>
+async fn get_xtream_http_data<T>(mut url: Url, action: &str, client: &Client) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
-    let client = Client::builder().user_agent(user_agent).build()?;
     url.query_pairs_mut().append_pair("action", action);
     let data = client.get(url).send().await?.json::<T>().await?;
     Ok(data)
@@ -320,11 +319,11 @@ pub async fn get_episodes(channel: Channel) -> Result<()> {
     }
     let mut source = sql::get_source_from_id(channel.source_id.context("no source id")?)?;
     let mut url = build_xtream_url(&mut source)?;
-    let user_agent = get_user_agent_from_source(&source)?;
+    let client = http::build_client_for_source(source.user_agent.as_deref())?;
     url.query_pairs_mut()
         .append_pair("series_id", &series_id.to_string());
     let mut series =
-        get_xtream_http_data::<XtreamSeries>(url, GET_SERIES_INFO, &user_agent).await?;
+        get_xtream_http_data::<XtreamSeries>(url, GET_SERIES_INFO, &client).await?;
     let mut episodes: Vec<XtreamEpisode> = series
         .episodes
         .into_values()
@@ -509,10 +508,10 @@ fn episode_to_channel(
 pub async fn get_epg(channel: Channel) -> Result<Vec<EPG>> {
     let mut source = sql::get_source_from_id(channel.source_id.context("no source id")?)?;
     let mut url = build_xtream_url(&mut source)?;
-    let user_agent = get_user_agent_from_source(&source)?;
+    let client = http::build_client_for_source(source.user_agent.as_deref())?;
     let stream_id = channel.stream_id.context("No stream id")?.to_string();
     url.query_pairs_mut().append_pair("stream_id", &stream_id);
-    let epg: XtreamEPG = get_xtream_http_data(url, GET_EPG, &user_agent).await?;
+    let epg: XtreamEPG = get_xtream_http_data(url, GET_EPG, &client).await?;
     let url = get_timeshift_url_base(&source)?;
     let current_time = Local::now();
     let mut otv_epgs = Vec::new();


### PR DESCRIPTION
## Summary

Complete backend overhaul adding 6 new Rust modules and updating 5 existing ones:

- **`http.rs`** - Centralized reqwest client with configurable proxy, user-agent (per-source and global), and connection timeout
- **`recording.rs`** - Server-side recording with active recording management, stop signals, and automatic cleanup
- **`scheduler.rs`** - Background EPG and source auto-refresh on configurable intervals (hours)
- **`backup.rs`** - Full database export/import (sources, channels, groups, settings, EPG watchlist) with versioned JSON format
- **`local_player.rs`** - MPEG-TS proxy via ffmpeg + warp, HEAD-request URL resolution for redirect streams, broadcast-based lifecycle with proper cleanup, VA-API hardware decode support
- **`main.rs`** - Panic handler for better error reporting

Updates `m3u.rs`, `xtream.rs`, `restream.rs` to use centralized HTTP client. Removes dead `get_user_agent_from_source` from `utils.rs`. Adds all new settings fields, tauri commands, scheduler startup in setup, and clean exit signal handling.

**Part 1 of 2** - This is the Rust backend. Part 2 adds the Angular frontend.

## New settings
- `user_agent`, `proxy`, `connection_timeout` (networking)
- `epg_refresh_interval`, `source_refresh_interval` (scheduler)
- `buffer_size`, `player_engine` (playback)

## Test plan
- [ ] `cargo check` passes
- [ ] Existing functionality (play, refresh, restream) still works
- [ ] New settings persist across restarts
- [ ] Recording starts/stops cleanly
- [ ] Backup export creates valid JSON, import restores correctly