### PR TITLE
Show current EPG program on channel tiles

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             channel_exists,
             update_source,
             get_epg,
+            get_now_playing_batch,
             download,
             add_epg,
             remove_epg,
@@ -427,6 +428,15 @@ fn update_source(source: Source) -> Result<(), String> {
 #[tauri::command]
 async fn get_epg(channel: Channel) -> Result<Vec<EPG>, String> {
     xtream::get_epg(channel).await.map_err(map_err_frontend)
+}
+
+#[tauri::command]
+async fn get_now_playing_batch(
+    channels: Vec<Channel>,
+) -> Result<std::collections::HashMap<i64, String>, String> {
+    xtream::get_now_playing_batch(channels)
+        .await
+        .map_err(map_err_frontend)
 }
 
 #[tauri::command]

--- a/src-tauri/src/xtream.rs
+++ b/src-tauri/src/xtream.rs
@@ -22,6 +22,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::join;
 use url::Url;
 
@@ -33,6 +34,7 @@ const GET_SERIES_CATEGORIES: &str = "get_series_categories";
 const GET_LIVE_STREAM_CATEGORIES: &str = "get_live_categories";
 const GET_VOD_CATEGORIES: &str = "get_vod_categories";
 const GET_EPG: &str = "get_simple_data_table";
+const GET_SHORT_EPG: &str = "get_short_epg";
 const LIVE_STREAM_EXTENSION: &str = "ts";
 const NO_SEASON_NUMBER: i64 = -9999;
 
@@ -107,6 +109,20 @@ struct XtreamEPGItem {
     has_archive: u8,
     start: String,
     end: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct ShortEPGResponse {
+    #[serde(default)]
+    epg_listings: Vec<ShortEPGItem>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct ShortEPGItem {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    now_playing: u8,
 }
 
 fn build_xtream_url(source: &mut Source) -> Result<Url> {
@@ -587,4 +603,66 @@ fn get_timeshift_url(mut url: Url, start: String, end: String, stream_id: &str) 
         .append_pair("start", &start)
         .append_pair("duration", &duration);
     Ok(url.to_string())
+}
+
+pub async fn get_now_playing_batch(
+    channels: Vec<Channel>,
+) -> Result<HashMap<i64, String>> {
+    let mut by_source: HashMap<i64, Vec<Channel>> = HashMap::new();
+    for ch in channels {
+        if let (Some(source_id), Some(_stream_id)) = (ch.source_id, ch.stream_id) {
+            by_source.entry(source_id).or_default().push(ch);
+        }
+    }
+
+    let mut result: HashMap<i64, String> = HashMap::new();
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(10));
+
+    for (source_id, channels) in by_source {
+        let source = sql::get_source_from_id(source_id)?;
+        let mut base_url = build_xtream_url(&mut source.clone())?;
+        let user_agent = get_user_agent_from_source(&source)?;
+        base_url.query_pairs_mut().append_pair("action", GET_SHORT_EPG);
+
+        let client = Client::builder().user_agent(&user_agent).build()?;
+
+        let mut handles = Vec::new();
+        for ch in channels {
+            let client = client.clone();
+            let mut url = base_url.clone();
+            let sem = semaphore.clone();
+            let channel_id = ch.id.unwrap_or(-1);
+            let stream_id = ch.stream_id.unwrap().to_string();
+
+            handles.push(tokio::spawn(async move {
+                let _permit = sem.acquire().await;
+                url.query_pairs_mut()
+                    .append_pair("stream_id", &stream_id)
+                    .append_pair("limit", "2");
+                let title: Option<String> = match client.get(url).send().await {
+                    Ok(resp) => {
+                        let text = resp.text().await.unwrap_or_default();
+                        serde_json::from_str::<ShortEPGResponse>(&text).ok().and_then(|e| {
+                            // Prefer now_playing entry, fall back to first entry
+                            let item = e.epg_listings.iter().find(|i| i.now_playing == 1)
+                                .or_else(|| e.epg_listings.first());
+                            item.and_then(|i| {
+                                BASE64_STANDARD.decode(&i.title).ok().and_then(|b| String::from_utf8(b).ok())
+                            })
+                        })
+                    },
+                    Err(_) => None,
+                };
+                (channel_id, title)
+            }));
+        }
+
+        for handle in handles {
+            if let Ok((id, Some(title))) = handle.await {
+                result.insert(id, title);
+            }
+        }
+    }
+
+    Ok(result)
 }

--- a/src/app/channel-tile/channel-tile.component.css
+++ b/src/app/channel-tile/channel-tile.component.css
@@ -23,6 +23,14 @@
   white-space: nowrap;
 }
 
+.channel-now-playing {
+  font-size: 0.75rem;
+  color: #8cb4ff;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .channel-source {
   font-size: 0.75rem;
   color: #adb5bd;

--- a/src/app/channel-tile/channel-tile.component.html
+++ b/src/app/channel-tile/channel-tile.component.html
@@ -9,7 +9,8 @@
   </div>
   <div class="channel-title-container d-flex flex-column justify-content-center">
     <div class="channel-title">{{ channel?.name }}</div>
-    <div class="channel-source">{{ getSourceName() }}</div>
+    <div *ngIf="nowPlaying" class="channel-now-playing">{{ nowPlaying }}</div>
+    <div *ngIf="!nowPlaying" class="channel-source">{{ getSourceName() }}</div>
   </div>
   <div class="ms-auto d-flex flex-column justify-content-center align-items-center h-100">
     <svg *ngIf="channel?.tv_archive === true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"

--- a/src/app/channel-tile/channel-tile.component.ts
+++ b/src/app/channel-tile/channel-tile.component.ts
@@ -49,6 +49,7 @@ export class ChannelTileComponent implements OnDestroy, AfterViewInit {
   @Input() channel?: Channel;
   @Input() id!: number;
   @Input() viewMode: number = 0;
+  @Input() nowPlaying: string = "";
   @ViewChild(MatMenuTrigger, { static: true }) matMenuTrigger!: MatMenuTrigger;
   menuTopLeftPosition = { x: 0, y: 0 };
   showImage: boolean = true;

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -104,7 +104,8 @@
     </div>
     <div class="row gy-3" [@fade]="channelsVisible ? 'visible' : 'hidden'">
       <app-channel-tile [attr.id]="i == 0 ? 'first' : null" *ngFor="let channel of channels; let i = index"
-        class="col-lg-4 col-md-4" [id]="i" [channel]="channel" [viewMode]="viewType"></app-channel-tile>
+        class="col-lg-4 col-md-4" [id]="i" [channel]="channel" [viewMode]="viewType"
+        [nowPlaying]="nowPlayingMap.get(channel.id!) || ''"></app-channel-tile>
     </div>
   </div>
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -99,6 +99,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
   loading = false;
   nodeStack: Stack = new Stack();
   showScrollTop = false;
+  nowPlayingMap: Map<number, string> = new Map();
 
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -283,6 +284,29 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
       this.error.handleError(e);
     }
     this.loading = false;
+    this.fetchNowPlaying();
+  }
+
+  async fetchNowPlaying() {
+    const xtreamLive = this.channels.filter(
+      (c) =>
+        c.media_type == MediaType.livestream &&
+        c.source_id != null &&
+        this.memory.XtreamSourceIds.has(c.source_id!)
+    );
+    if (xtreamLive.length === 0) return;
+    try {
+      const data: Record<string, string> = await invoke("get_now_playing_batch", {
+        channels: xtreamLive,
+      });
+      const map = new Map<number, string>();
+      for (const [id, title] of Object.entries(data)) {
+        map.set(Number(id), title);
+      }
+      this.nowPlayingMap = map;
+    } catch (e) {
+      console.error("Failed to fetch now playing", e);
+    }
   }
 
   checkScrollTop() {


### PR DESCRIPTION
## Summary
- Adds inline "now playing" EPG info on channel tiles for Xtream sources
- Uses the `get_short_epg` Xtream API to fetch the current program for visible livestream channels
- Displays the program title in blue below the channel name, replacing the source name when EPG data is available
- Requests are batched and run concurrently (capped at 10 parallel) to avoid blocking the UI or flooding the API

## Screenshots

![inline-epg](https://github.com/user-attachments/assets/placeholder)

## How it works
1. After the channel list loads, the frontend filters for Xtream livestream channels
2. Calls a new `get_now_playing_batch` Tauri command with those channels
3. Backend fetches `get_short_epg` for each stream ID concurrently, decodes base64 titles
4. Returns a map of channel ID → current program title
5. Channel tiles display the title when available, falling back to source name

## Test plan
- [x] Tested with Xtream source — EPG titles display correctly on channel tiles
- [ ] Verify no regression on M3U-only sources (should show source name as before)
- [ ] Verify channels without EPG data gracefully fall back to source name

🤖 Generated with [Claude Code](https://claude.com/claude-code)