### PR TITLE
fix(xtream): validate HTTP response before JSON parsing (Closes #338)

### DIFF
--- a/src-tauri/src/xtream.rs
+++ b/src-tauri/src/xtream.rs
@@ -202,7 +202,35 @@ where
 {
     let client = Client::builder().user_agent(user_agent).build()?;
     url.query_pairs_mut().append_pair("action", action);
-    let data = client.get(url).send().await?.json::<T>().await?;
+    let response = client.get(url).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "Xtream API returned HTTP {} for action '{}'. Body preview: {}",
+            status.as_u16(),
+            action,
+            &body[..body.len().min(200)]
+        ));
+    }
+    let text = response.text().await?;
+    if text.is_empty() {
+        return Err(anyhow!("Xtream API returned empty body for action '{}'.", action));
+    }
+    // Check if the response is valid JSON before parsing
+    if !text.starts_with('{') && !text.starts_with('[') {
+        return Err(anyhow!(
+            "Xtream API returned non-JSON body for action '{}': {}",
+            action,
+            &text[..text.len().min(200)]
+        ));
+    }
+    let data = serde_json::from_str(&text).map_err(|e| anyhow!(
+        "Failed to parse JSON from Xtream API (action '{}'): {}. Body: {}",
+        action,
+        e,
+        &text[..text.len().min(200)]
+    ))?;
     Ok(data)
 }
 
@@ -596,7 +624,25 @@ async fn get_status(source: &mut Source) -> Result<(i64, XtreamStatus)> {
     let url = build_xtream_url(source)?;
     let user_agent = get_user_agent_from_source(&source)?;
     let client = Client::builder().user_agent(user_agent).build()?;
-    let data = client.get(url).send().await?.json::<XtreamStatus>().await?;
+    let response = client.get(url).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "Xtream API returned HTTP {} in get_status. Body preview: {}",
+            status.as_u16(),
+            &body[..body.len().min(200)]
+        ));
+    }
+    let text = response.text().await?;
+    if text.is_empty() {
+        return Err(anyhow!("Xtream API returned empty body in get_status."));
+    }
+    let data = serde_json::from_str::<XtreamStatus>(&text).map_err(|e| anyhow!(
+        "Failed to parse XtreamStatus JSON: {}. Body: {}",
+        e,
+        &text[..text.len().min(200)]
+    ))?;
     Ok((source.id.context("no id")?, data))
 }
 


### PR DESCRIPTION
## Summary

Fix the `expected value at line 1 column 1` error when Xtream API returns non-JSON responses (empty body, HTML error pages, HTTP 502/404). Two call sites fixed.

## What Changed

**Before**: `client.get(url).send().await?.json::<T>().await?`

**After**: validates HTTP status + empty body + non-JSON content before deserializing.

Two functions patched: `get_xtream_http_data<T>()` and `get_status()`.

## Why / Why This Shape

- Issue #338 root cause: Xtream API server returns HTML error (502/404) or empty response leading to `.json()` panic.
- The fix gives a **meaningful error message** with HTTP status and body preview for debugging.

## Compatibility Note

Valid Xtream API responses are unchanged.

## Scope Boundary

- Does NOT add retry logic.
- Does NOT change the success path.
- Does NOT add logging infrastructure.

## Validation

```bash
cd src-tauri && cargo test
# → 2 passed; 0 failed
```