### PR TITLE
fix(headers): sanitize CRLF and comma injection in HTTP headers

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -213,10 +213,12 @@ fn set_headers(
     let headers = headers.unwrap_or_default();
     let mut headers_vec: Vec<String> = Vec::with_capacity(2);
     if let Some(origin) = headers.http_origin {
-        headers_vec.push(format!("{HTTP_ORIGIN}{origin}"));
+        let safe_origin = origin.replace('\r', "").replace('\n', "").replace(',', "");
+        headers_vec.push(format!("{HTTP_ORIGIN}{safe_origin}"));
     }
     if let Some(referrer) = headers.referrer {
-        headers_vec.push(format!("{HTTP_REFERRER}{referrer}"));
+        let safe_referrer = referrer.replace('\r', "").replace('\n', "").replace(',', "");
+        headers_vec.push(format!("{HTTP_REFERRER}{safe_referrer}"));
     }
     if let Some(user_agent) = headers
         .user_agent

--- a/src-tauri/src/restream.rs
+++ b/src-tauri/src/restream.rs
@@ -36,16 +36,18 @@ fn start_ffmpeg_listening(channel: Channel, restream_dir: PathBuf) -> Result<Chi
     let mut command = Command::new(get_bin(FFMPEG_BIN_NAME));
     if let Some(headers) = headers {
         if let Some(referrer) = headers.referrer {
+            let safe_referrer = referrer.replace('\r', "").replace('\n', "");
             command.arg("-headers");
-            command.arg(format!("Referer: {referrer}"));
+            command.arg(format!("Referer: {safe_referrer}"));
         }
         if let Some(user_agent) = headers.user_agent {
             command.arg("-headers");
             command.arg(format!("User-Agent: {user_agent}"));
         }
         if let Some(origin) = headers.http_origin {
+            let safe_origin = origin.replace('\r', "").replace('\n', "");
             command.arg("-headers");
-            command.arg(format!("Origin: {origin}"));
+            command.arg(format!("Origin: {safe_origin}"));
         }
         if let Some(ignore_ssl) = headers.ignore_ssl {
             if ignore_ssl {


### PR DESCRIPTION
## Summary

Strips \\r \\n and commas from origin/referrer before passing to ffmpeg -headers and mpv --http-header-fields. Prevents CRLF injection (arbitrary HTTP header forging) and comma injection.

## What Changed

- `src-tauri/src/mpv.rs:215-220` — sanitize origin/referrer in set_headers()
- `src-tauri/src/restream.rs:38-49` — sanitize referrer/origin before ffmpeg -headers

## Why

Reported as https://github.com/Fredolx/open-tv/issues/424 — CRLF injection allows forging arbitrary HTTP headers from the victim's machine.

## Compatibility Note

No breaking changes. Legitimate referrers do not contain \\r \\n or raw commas.

## Validation

`cargo check` passes.