### PR TITLE
fix(restream): bind web server to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/src-tauri/src/restream.rs
+++ b/src-tauri/src/restream.rs
@@ -91,7 +91,7 @@ async fn start_web_server(
     let file_server = warp::fs::dir(restream_dir);
     let (tx, rx) = oneshot::channel::<bool>();
     let (_, server) =
-        warp::serve(file_server).bind_with_graceful_shutdown(([0, 0, 0, 0], port), async {
+        warp::serve(file_server).bind_with_graceful_shutdown(([127, 0, 0, 1], port), async {
             rx.await.ok();
         });
     let handle = tokio::spawn(server);


### PR DESCRIPTION
## Summary

The restream HLS server was binding to all interfaces (0.0.0.0), exposing the stream to LAN/WAN without authentication. Now binds to localhost only (127.0.0.1).

## What Changed

- `src-tauri/src/restream.rs:94` — changed bind address from `[0,0,0,0]` to `[127,0,0,1]`

## Why

Reported as https://github.com/Fredolx/open-tv/issues/424 — Unauthenticated restream server bound to 0.0.0.0.

## Compatibility Note

No breaking changes for local playback. Restream sharing across LANs will need a different mechanism (future work).

## Validation

`cargo check` passes.