### PR TITLE
fix(tauri): enable Content Security Policy

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: blob:; media-src 'self' https: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Replaces `"csp": null` with a strict CSP that blocks inline scripts, external scripts, object embeddings, and frame ancestors.

## What Changed

- `src-tauri/tauri.conf.json:22-24` — replaced `"csp": null` with strict policy

## Why

Reported as https://github.com/Fredolx/open-tv/issues/424 — Disabled CSP allows any XSS from M3U channel metadata to execute with full Tauri IPC access.

## Compatibility Note

If the app uses any inline scripts or dynamic script loading, those will break. Test build recommended before merge.

## Validation

`cargo check` passes.